### PR TITLE
feat: DSD-48 [FE] Add auth check

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -3,36 +3,37 @@ import { NextResponse, type NextRequest } from "next/server";
 import type { Database } from "./utils/supabase/types/database.types.ts";
 
 export async function middleware(request: NextRequest) {
-  let supabaseResponse = NextResponse.next({
-    request,
-  });
+  let supabaseResponse = NextResponse.next({ request });
 
   const supabase = createServerClient<Database>(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
       cookies: {
-        getAll() {
-          return request.cookies.getAll();
-        },
-        setAll(cookiesToSet) {
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          cookiesToSet.forEach(({ name, value, options }) =>
-            request.cookies.set(name, value)
-          );
-          supabaseResponse = NextResponse.next({
-            request,
+        getAll: () => request.cookies.getAll(),
+        setAll: (cookiesToSet) => {
+          cookiesToSet.forEach(({ name, value, options }) => {
+            request.cookies.set(name, value);
           });
-          cookiesToSet.forEach(({ name, value, options }) =>
-            supabaseResponse.cookies.set(name, value, options)
-          );
+          supabaseResponse = NextResponse.next({ request });
+          cookiesToSet.forEach(({ name, value, options }) => {
+            supabaseResponse.cookies.set(name, value, options);
+          });
         },
       },
-    }
+    },
   );
 
-  // refreshing the auth token
-  await supabase.auth.getUser();
+  // Allow public access only to the home page
+  const isHomePage = request.nextUrl.pathname === "/";
+
+  // Fetch authenticated user
+  const { data, error } = await supabase.auth.getUser();
+
+  // If the user is NOT logged in and tries to access a restricted page (anything other than the home page), redirect them to the home page.
+  if (!isHomePage && (error || !data?.user)) {
+    return NextResponse.redirect(new URL("/", request.url));
+  }
 
   return supabaseResponse;
 }


### PR DESCRIPTION
# DSD-48 [FE] Add auth check to the top of all pages that should only be accessible by login

## Changes  
- Added middleware to restrict access to authenticated users  
- Public access is allowed only for the home page (`/`)  
- Integrated Supabase authentication to check user session  
- Redirecting unauthenticated users to the home page  

## Why?  
Handling authentication in the backend ensures that restricted content is never exposed, even if frontend checks are bypassed. Middleware blocks unauthorized requests before they reach protected pages, enforcing access control at the server level.

## Testing  
- Access the home page while **not logged in** → Confirm that it remains accessible.  
- Try visiting a restricted page while **not logged in** → Verify redirection to `/`.  
- Log in and navigate to restricted pages → Confirm that they load correctly. 