### PR TITLE
Bug/DSD-79 convert times utc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@types/nodemailer": "^6.4.17",
         "clsx": "^2.1.1",
         "framer-motion": "^12.4.10",
+        "luxon": "^3.5.0",
         "next": "15.2.1",
         "nodemailer": "^6.10.0",
         "react": "^19.0.0",
@@ -33,6 +34,7 @@
       "devDependencies": {
         "@eslint/eslintrc": "^3",
         "@tailwindcss/postcss": "^4",
+        "@types/luxon": "^3.4.2",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -1336,6 +1338,13 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/luxon": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.4.2.tgz",
+      "integrity": "sha512-TifLZlFudklWlMBfhubvgqTXRzLDI5pCbGa4P8a3wPyUQSW+1xQ5eDsreP9DWHX3tjq1ke96uYG/nwundroWcA==",
       "dev": true,
       "license": "MIT"
     },
@@ -4494,6 +4503,15 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/luxon": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.5.0.tgz",
+      "integrity": "sha512-rh+Zjr6DNfUYR3bPwJEnuwDdqMbxZW7LOQfUN4B54+Cl+0o5zaU9RJ6bcidfDtC1cWCZXQ+nvX8bf6bAji37QQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@types/nodemailer": "^6.4.17",
     "clsx": "^2.1.1",
     "framer-motion": "^12.4.10",
+    "luxon": "^3.5.0",
     "next": "15.2.1",
     "nodemailer": "^6.10.0",
     "react": "^19.0.0",
@@ -34,6 +35,7 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3",
     "@tailwindcss/postcss": "^4",
+    "@types/luxon": "^3.4.2",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/src/components/schedule/lib/generate-timeslots.ts
+++ b/src/components/schedule/lib/generate-timeslots.ts
@@ -123,7 +123,6 @@ export function generateTimeslots(
           const slotStart = startTime.toMillis();
           const slotEnd = nextSlot.toMillis();
 
-          // return !(apptEnd <= slotStart || apptStart >= slotEnd);
           return apptStart < slotEnd && apptEnd > slotStart;
         });
 

--- a/src/components/schedule/lib/generate-timeslots.ts
+++ b/src/components/schedule/lib/generate-timeslots.ts
@@ -1,3 +1,4 @@
+import { DateTime } from "luxon";
 import type { WorkDay } from "@/utils/supabase/types";
 import { APPOINTMENT_LEAD_TIME } from "../types/calendar.types";
 import type {
@@ -21,6 +22,7 @@ export function generateTimeslots(
   appointments: Appointment[],
   existingIds: number[],
 ) {
+  const timeZone = "America/Denver";
   const timeslots: Timeslot[] = [];
   let maxId = existingIds.length > 0 ? Math.max(...existingIds) : 0;
 
@@ -40,6 +42,30 @@ export function generateTimeslots(
       !break_start_time ||
       !break_end_time
     ) {
+      console.warn(`Technician ${id} has missing time data. Skipping.`);
+      return;
+    }
+
+    const workStart = DateTime.fromISO(work_start_time, {
+      zone: timeZone,
+    }).toUTC();
+    const workEnd = DateTime.fromISO(work_end_time, {
+      zone: timeZone,
+    }).toUTC();
+    const breakStart = DateTime.fromISO(break_start_time, {
+      zone: timeZone,
+    }).toUTC();
+    const breakEnd = DateTime.fromISO(break_end_time, {
+      zone: timeZone,
+    }).toUTC();
+
+    if (
+      !workStart.isValid ||
+      !workEnd.isValid ||
+      !breakStart.isValid ||
+      !breakEnd.isValid
+    ) {
+      console.error(`Invalid time conversion for technician ${id}. Skipping.`);
       return;
     }
 
@@ -48,37 +74,34 @@ export function generateTimeslots(
     );
 
     for (let i = 0; i < APPOINTMENT_LEAD_TIME; i++) {
-      const currentDate = new Date();
-      currentDate.setHours(0, 0, 0, 0);
-      currentDate.setDate(currentDate.getDate() + i);
+      const currentDate = DateTime.now().plus({ days: i }).startOf("day");
+      if (i === 0) continue;
 
-      const today = new Date();
-      today.setHours(0, 0, 0, 0);
-      if (currentDate.getTime() === today.getTime()) {
-        continue;
-      }
-
-      const dayOfWeek = currentDate.getDay();
-      const workDay = dayOfWeekMap[dayOfWeek];
+      const workDay = dayOfWeekMap[currentDate.weekday % 7];
       if (!work_days?.includes(workDay)) continue;
 
-      let startTime = new Date(
-        currentDate.toISOString().slice(0, 10) + `T${work_start_time}`,
-      );
-      const endTime = new Date(
-        currentDate.toISOString().slice(0, 10) + `T${work_end_time}`,
-      );
-      const breakStart = new Date(
-        currentDate.toISOString().slice(0, 10) + `T${break_start_time}`,
-      );
-      const breakEnd = new Date(
-        currentDate.toISOString().slice(0, 10) + `T${break_end_time}`,
-      );
+      let startTime = DateTime.fromISO(
+        `${currentDate.toISODate()}T${work_start_time}`,
+        { zone: timeZone },
+      ).toUTC();
+      const endTime = DateTime.fromISO(
+        `${currentDate.toISODate()}T${work_end_time}`,
+        { zone: timeZone },
+      ).toUTC();
+      const breakStart = DateTime.fromISO(
+        `${currentDate.toISODate()}T${break_start_time}`,
+        { zone: timeZone },
+      ).toUTC();
+      const breakEnd = DateTime.fromISO(
+        `${currentDate.toISODate()}T${break_end_time}`,
+        { zone: timeZone },
+      ).toUTC();
 
-      const slotDuration = 60 * 60 * 1000;
+      let failsafeCounter = 0;
+      const maxIterations = 24;
 
-      while (startTime < endTime) {
-        const nextSlot = new Date(startTime.getTime() + slotDuration);
+      while (startTime < endTime && failsafeCounter < maxIterations) {
+        const nextSlot = startTime.plus({ hours: 1 });
 
         if (
           (startTime >= breakStart && startTime < breakEnd) ||
@@ -89,27 +112,38 @@ export function generateTimeslots(
         }
 
         const isBooked = techAppointments.some((appt) => {
-          if (!appt.appointment_start || !appt.appointment_end) {
-            return false;
-          }
-          return (
-            new Date(appt.appointment_start) < nextSlot &&
-            new Date(appt.appointment_end) > startTime
-          );
+          if (!appt.appointment_start || !appt.appointment_end) return false;
+
+          const apptStart = DateTime.fromISO(appt.appointment_start, {
+            zone: "utc",
+          }).toMillis();
+          const apptEnd = DateTime.fromISO(appt.appointment_end, {
+            zone: "utc",
+          }).toMillis();
+          const slotStart = startTime.toMillis();
+          const slotEnd = nextSlot.toMillis();
+
+          // return !(apptEnd <= slotStart || apptStart >= slotEnd);
+          return apptStart < slotEnd && apptEnd > slotStart;
         });
 
         if (!isBooked) {
           timeslots.push({
             id: ++maxId,
-            start: startTime.toISOString(),
-            end: nextSlot.toISOString(),
-            extendedProps: {
-              technicianId: id,
-            },
+            start: startTime.toISO() || "",
+            end: nextSlot.toISO() || "",
+            extendedProps: { technicianId: id },
           });
         }
 
         startTime = nextSlot;
+        failsafeCounter++;
+      }
+
+      if (failsafeCounter >= maxIterations) {
+        console.error(
+          `Possible infinite loop detected for technician ${id} on ${currentDate.toISODate()}`,
+        );
       }
     }
   });


### PR DESCRIPTION
# [BE] DSD-79 Convert times to UTC
https://jarrod-van-doren.atlassian.net/browse/DSD-79?atlOrigin=eyJpIjoiNzJkYzEyODM0MTc0NDBiNmI3N2UwYzJjYWM4ZDI3ZTUiLCJwIjoiaiJ9

## Summary
This PR fixes several bugs:

- Times were off by several hours due to some being in UTC and some not
- The `generate-timeslot` logic was allowing an appointment to be booked for the same date and time more than once

## Changes

- Install Luxon library for time normalization
- Add "Denver" timezone
- Convert work hours, break hours, and appointment times to UTC in the timezone
- Create timeslots in UTC in the timezone
- Adjust logic to not allow overlaps and prevent infinite loops

## Testing
Manual testing was performed to ensure that the work hours aligned with the appointment slots and that no available timeslots overlap break times or appointments.

### Booking appointment process:
Select date:
<img width="495" alt="Screenshot 2025-03-14 at 10 23 30 PM" src="https://github.com/user-attachments/assets/74794750-5642-46f5-be1e-8a88064fb6ad" />

Confirm date (complete booking - not shown):
<img width="573" alt="Screenshot 2025-03-14 at 10 23 38 PM" src="https://github.com/user-attachments/assets/64f30289-065d-4df4-a861-ea3d5b9bb337" />

Go back to same department and date and `12:00 pm -1:00 pm` slot is no longer there:
<img width="491" alt="Screenshot 2025-03-14 at 10 23 59 PM" src="https://github.com/user-attachments/assets/0b3d585e-7e9b-4542-b47b-48ad3ad82aef" />

### Checking to make sure that if all appointments from one day are booked that the day no longer displays as highlighted showing available timeslots:

Before booking all appointments for March 17:
<img width="470" alt="Screenshot 2025-03-14 at 10 31 13 PM" src="https://github.com/user-attachments/assets/64f518e0-e706-46df-a916-0acad5acf173" />

Last timeslot available:
<img width="514" alt="Screenshot 2025-03-14 at 10 29 36 PM" src="https://github.com/user-attachments/assets/94aee66d-1204-4f32-844d-bb7cfdc571c0" />

March 17 no longer highlighted after last timeslot is booked:
<img width="513" alt="Screenshot 2025-03-14 at 10 29 56 PM" src="https://github.com/user-attachments/assets/ac7333bb-9d67-4715-a00b-19cbdc96ffbd" />



