### PR TITLE
feat: Add email notification in work order creation

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -49,6 +49,6 @@ export async function middleware(request: NextRequest) {
 
 export const config = {
   matcher: [
-    "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
+    "/((?!_next/static|_next/image|favicon.ico|api/|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
   ],
 };


### PR DESCRIPTION
# DSD-101 [BE] Hook up work order submission to send email

## Changes  
### **Email Notification**  
- Sends an email to the assigned technician when a work order is created  
- Includes missing parts details in the email if any are unavailable

### Middleware  
- Updated `matcher` in `config` to exclude `/api/` routes  
- Ensures middleware does not intercept API requests  