### PR TITLE
Bug/DSD-122 fix step1 form reset

### DIFF
--- a/src/components/schedule/step-1-work-order-form.tsx
+++ b/src/components/schedule/step-1-work-order-form.tsx
@@ -31,7 +31,7 @@ interface Step1DepartmentServiceProps {
 
 export default function Step1DepartmentService({
   register,
-  reset,
+  // reset,
   departments,
   setIsLoading,
   isLoading,
@@ -72,7 +72,9 @@ export default function Step1DepartmentService({
   };
 
   const handleReset = () => {
-    reset({ departmentId: undefined, serviceTypeId: undefined });
+    setValue("departmentId", "" as unknown as number);
+    setValue("serviceTypeId", "" as unknown as number);
+    setValue("technicianId", "");
     setIsDisabled(true);
     setServiceTypes([]);
   };


### PR DESCRIPTION
# [FE] [DSD-122](https://jarrod-van-doren.atlassian.net/browse/DSD-122?atlOrigin=eyJpIjoiMDZlZWVhNDgyMTMxNDAyZTgxNjAwMjU1MzViNmFjNzIiLCJwIjoiaiJ9) Fix step 1 work order form reset

## Summary
This PR implements fixing the bug where the department select input would not reset.

## Changes
Utilized React-Hook-Form's "setValue" and explicitly set the value to an empty string (or `"" as unknown as number` for number types.

Before:
<img width="701" alt="Screenshot 2025-03-19 at 10 59 56 PM" src="https://github.com/user-attachments/assets/467f5e57-cc27-4084-aaa9-ee6f74a0b6a3" />
<img width="699" alt="Screenshot 2025-03-19 at 11 00 04 PM" src="https://github.com/user-attachments/assets/1a34cb78-eb18-480c-8873-38611e3a942e" />


After: 
<img width="700" alt="Screenshot 2025-03-19 at 10 59 15 PM" src="https://github.com/user-attachments/assets/4409024a-46e7-4f8c-9d9f-f79142e474b8" />
<img width="694" alt="Screenshot 2025-03-19 at 10 59 22 PM" src="https://github.com/user-attachments/assets/75da9c28-fc44-4a7a-9f9b-a8a44e5ec41a" />
