### PR TITLE
Feat/DSD-157 create tooltip

### DIFF
--- a/src/app/(main)/admin/work-orders/page.tsx
+++ b/src/app/(main)/admin/work-orders/page.tsx
@@ -16,7 +16,7 @@ export default async function Page() {
 
   return (
     <div className="px-4 py-12">
-      <div className="mx-10 flex items-center justify-between gap-2">
+      <div className="mx-10 flex items-center justify-between gap-2 pb-2">
         <h1 className="text-3xl font-bold tracking-tight">
           Manage Work Orders
         </h1>

--- a/src/app/(main)/admin/work-orders/page.tsx
+++ b/src/app/(main)/admin/work-orders/page.tsx
@@ -15,8 +15,8 @@ export default async function Page() {
   if (!profile) notFound();
 
   return (
-    <div className="container mx-auto space-y-4 px-4 py-12">
-      <div className="flex items-center justify-between gap-2">
+    <div className="px-4 py-12">
+      <div className="mx-10 flex items-center justify-between gap-2">
         <h1 className="text-3xl font-bold tracking-tight">
           Manage Work Orders
         </h1>
@@ -24,7 +24,7 @@ export default async function Page() {
           <FontAwesomeIcon icon={faLeftLong} />
         </Button>
       </div>
-      <div className="bg-muted h-1" />
+      <div className="bg-muted mx-10 h-1" />
       <WorkOrderList />
     </div>
   );

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -123,3 +123,7 @@ body.modal-open {
   scrollbar-width: thin;
   scrollbar-color: hsl(var(--border)) transparent;
 }
+
+.tooltip-item {
+  cursor: pointer;
+}

--- a/src/components/dashboard/client-dashboard.tsx
+++ b/src/components/dashboard/client-dashboard.tsx
@@ -3,20 +3,20 @@ import { Button } from "../ui/button";
 
 export const ClientDashboard = () => {
   return (
-    <div className="m-2 py-12 md:m-4">
-      <div className="px-10">
+    <div className="m-0 py-12 md:m-2 md:m-4">
+      <div className="px-4 lg:px-10">
         <h1 className="text-3xl font-bold tracking-tight">Dashboard</h1>
         <div className="bg-muted h-1" />
       </div>
-      <h2 className="pt-2 pl-10 text-xl font-semibold text-blue-800">
-        Schedule
+      <h2 className="pt-2 pl-4 text-xl font-semibold text-blue-800 lg:pl-10">
+        Schedule Appointment
       </h2>
       <div className="m-0 flex flex-col items-center gap-2 rounded-none bg-blue-50 p-2 text-xs md:m-2 md:mx-2 md:mb-3 md:gap-3 md:rounded-lg md:p-3 lg:mx-10 lg:mb-4 lg:p-4">
         <Button asLink href="/schedule">
           Schedule an appointment now
         </Button>
       </div>
-      <h2 className="pt-2 pl-10 text-xl font-semibold text-blue-800">
+      <h2 className="pt-4 pl-4 text-xl font-semibold text-blue-800 lg:pl-10">
         Appointments
       </h2>
       <WorkOrderList />

--- a/src/components/dashboard/technician-dashboard.tsx
+++ b/src/components/dashboard/technician-dashboard.tsx
@@ -9,11 +9,11 @@ export default function TechnicianDashboard() {
         <div className="bg-muted h-1" />
       </div>
       <h2 className="pt-4 pl-10 text-xl font-semibold text-blue-800">
-        Your Schedule
+        Your Work Orders
       </h2>
       <WorkOrderList />
       <h2 className="pt-2 pl-10 text-xl font-semibold text-blue-800">
-        Your Calendar
+        Your Schedule
       </h2>
       <TechnicianCalendar />
     </div>

--- a/src/components/ui/tooltip.css
+++ b/src/components/ui/tooltip.css
@@ -1,0 +1,52 @@
+.tooltip-container {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+}
+
+.tooltip {
+  width: 100px;
+  font-size: 12px;
+  font-weight: 400;
+  background-color: #e2e8f0;
+  color: #000;
+  text-align: center;
+  padding: 12px;
+  border-radius: 6px;
+  position: absolute;
+  right: -25px;
+  top: -65px;
+  visibility: hidden;
+  transform: translateY(10px);
+  transition:
+    opacity 0.3s ease-in-out,
+    transform 0.3s ease-in-out,
+    visibility 0.3s ease-in-out;
+  box-shadow: 0px 3px 4px rgba(0, 0, 0, 0.1);
+}
+
+.arrow {
+  width: 0;
+  height: 0;
+  border-left: 12px solid transparent;
+  border-right: 12px solid transparent;
+  border-top: 12px solid #e2e8f0;
+  position: absolute;
+  bottom: -12px;
+  left: calc(50% - 12px);
+}
+
+.tooltip.open {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+}
+
+.tooltip:not(.open) {
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(0);
+}

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useState } from "react";
+import { ReactNode } from "react";
+import "./tooltip.css";
+
+interface TooltipProps {
+  infoText: string;
+  children?: ReactNode;
+}
+
+export default function Tooltip({ infoText, children }: TooltipProps) {
+  const [showTooltip, setShowTooltip] = useState(false);
+  const [isVisible, setIsVisible] = useState(false);
+  let timeout: NodeJS.Timeout;
+
+  const handleMouseEnter = () => {
+    clearTimeout(timeout);
+    setShowTooltip(true);
+    setIsVisible(true);
+  };
+  const handleMouseLeave = () => {
+    timeout = setTimeout(() => {
+      setShowTooltip(false);
+    }, 500);
+    setIsVisible(false);
+  };
+
+  return (
+    <div
+      className="tooltip-container"
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+    >
+      {children}
+
+      <div
+        className={`tooltip ${showTooltip ? "open" : ""} ${isVisible ? "visible" : ""}`}
+      >
+        {infoText}
+        <div className="arrow" />
+      </div>
+    </div>
+  );
+}

--- a/src/features/dashboard/components/work-order-card.tsx
+++ b/src/features/dashboard/components/work-order-card.tsx
@@ -17,6 +17,7 @@ import ServicePartsTable from "./service-parts-table";
 import { WorkOrderActionButtons } from "./work-order-action-buttons";
 import { AnimatePresence, motion } from "framer-motion";
 import { UpdateApptNotesDialog } from "./update-appt-notes-dialog";
+import Tooltip from "@/components/ui/tooltip";
 
 interface WorkOrderCardProps {
   workOrder: HydratedWorkOrder;
@@ -117,33 +118,14 @@ export default function WorkOrderCard({
           </div>
           <div className="mt-3 mr-4 flex flex-grow flex-row md:mt-0 md:mr-4 md:flex-wrap lg:flex-row">
             <div className="mr-4 w-1/2 md:mr-0 md:mb-3 md:w-full md:max-w-[100px] lg:mr-16">
-              {(userRole === "CLIENT" || userRole === "ADMIN") && (
-                <WorkOrderGroup labelText="Technician">
-                  <div className="flex items-center">
-                    {userRole === "ADMIN" && hasMissingParts && (
-                      <FontAwesomeIcon
-                        icon={faWrench}
-                        className="mr-2 text-red-500"
-                      />
-                    )}
-                    <span>
-                      {workOrder.technician.first_name}{" "}
-                      {workOrder.technician.last_name.slice(0, 1)}.
-                    </span>
-                  </div>
-                </WorkOrderGroup>
-              )}
-              {userRole === "TECHNICIAN" && (
-                <WorkOrderGroup labelText="Missing parts?">
-                  {hasMissingParts && (
-                    <FontAwesomeIcon
-                      icon={faWrench}
-                      className="mr-2 text-red-500"
-                    />
-                  )}
-                  {hasMissingParts ? "Yes" : "No"}
-                </WorkOrderGroup>
-              )}
+              <WorkOrderGroup labelText="Technician">
+                <div className="flex items-center">
+                  <span>
+                    {workOrder.technician.first_name}{" "}
+                    {workOrder.technician.last_name.slice(0, 1)}.
+                  </span>
+                </div>
+              </WorkOrderGroup>
             </div>
             <div className="flex w-1/2">
               <WorkOrderGroup labelText="Status">
@@ -161,6 +143,15 @@ export default function WorkOrderCard({
           </div>
         </div>
         <div className="flex items-center">
+          {(userRole === "ADMIN" || userRole === "TECHNICIAN") &&
+            hasMissingParts && (
+              <Tooltip infoText="Missing parts">
+                <FontAwesomeIcon
+                  icon={faWrench}
+                  className="tooltip-item mr-4 text-lg text-blue-900"
+                />
+              </Tooltip>
+            )}
           <span
             className="ml-auto cursor-pointer pr-2 text-right text-xl font-medium text-blue-500"
             onClick={() => setIsExpanded(!isExpanded)}

--- a/src/features/dashboard/components/work-order-list-admin.tsx
+++ b/src/features/dashboard/components/work-order-list-admin.tsx
@@ -5,6 +5,7 @@ import { Select } from "@/components/ui/select";
 import { HydratedWorkOrder } from "@/utils/supabase/types";
 import WorkOrderCard from "./work-order-card";
 import PaginationWrapper from "./pagination-wrapper";
+import { DateTime } from "luxon";
 
 interface WorkOrdersGroupedByTechnician {
   [technicianId: string]: {
@@ -25,6 +26,8 @@ export default function WorkOrderListAdmin({
   todayAppointments,
 }: WorkOrderListAdminProps) {
   const [selectedTechnician, setSelectedTechnician] = useState("ALL");
+
+  const today = DateTime.local().startOf("day");
 
   const technicianOptions = Object.keys(workOrdersGroupedByTechnician).map(
     (technicianId) => {
@@ -57,7 +60,7 @@ export default function WorkOrderListAdmin({
       {userRole === "ADMIN" && (
         <>
           <h3 className="text-lg font-bold text-blue-800">
-            Today&apos;s Work Orders:
+            Today&apos;s Appointments - {today.toLocaleString()}:
           </h3>
           {todayAppointments.length > 0 ? (
             todayAppointments.map((workOrder) => (

--- a/src/features/dashboard/components/work-order-list.tsx
+++ b/src/features/dashboard/components/work-order-list.tsx
@@ -120,7 +120,9 @@ export default async function WorkOrderList() {
       {(userRole === "TECHNICIAN" || userRole === "CLIENT") && (
         <>
           <h3 className="text-lg font-bold text-blue-800">
-            Today&apos;s Appointments - {today.toLocaleString()}:
+            Today&apos;s{" "}
+            {userRole === "CLIENT" ? "Appointments" : "Work Orders"} -{" "}
+            {today.toLocaleString()}:
           </h3>
           {todayAppointments.length > 0 ? (
             todayAppointments.map((workOrder) => (


### PR DESCRIPTION
# [FE] [DSD-157 ](https://jarrod-van-doren.atlassian.net/browse/DSD-157?atlOrigin=eyJpIjoiYWM0OTY0MWJlNjM2NDcwZDhmNWQzMGUwMjg0ZThmZDEiLCJwIjoiaiJ9)Create tooltip for missing parts

## Summary
This PR implements the addition of a tooltip for the "Missing parts" icon indicator. It also includes some minor style tweaks.

## Changes
### Move the wrench icon closer to the expand button and change it to blue. Add tooltip on hover:
Before:
<img width="1244" alt="Screenshot 2025-03-19 at 5 24 51 PM" src="https://github.com/user-attachments/assets/ea7acd90-bf57-4126-bb9b-f3a6cc93bec5" />

After:
https://github.com/user-attachments/assets/b0a7d835-df86-4746-a010-44122a9df56c

### Wrench icon only displays when work order has missing parts:
<img width="1189" alt="Screenshot 2025-03-20 at 10 55 04 AM" src="https://github.com/user-attachments/assets/29596b38-1558-4d19-add0-b2e5d877cf07" />


### Change conditional columns so that instead of having "Missing parts" column for technician, all users will see the "Technician" name. This can also ensure a technician that the appointments showing up on their dashboard were assigned to them.

Before:
<img width="1151" alt="Screenshot 2025-03-20 at 11 01 53 AM" src="https://github.com/user-attachments/assets/126a4a7d-28a5-4dbf-ad7e-195ca9a55147" />

After:
<img width="1168" alt="Screenshot 2025-03-20 at 11 00 53 AM" src="https://github.com/user-attachments/assets/01555e32-4d45-418d-bdf9-6a9a0186f8b3" />

### Lessen padding on Admin Work Card List so on large screens they can be their full width and more compact:
Before:
<img width="1262" alt="Screenshot 2025-03-20 at 11 03 26 AM" src="https://github.com/user-attachments/assets/4d2575f6-b61e-4ad4-8879-43c31834b5f0" />

After:
<img width="1266" alt="Screenshot 2025-03-20 at 11 04 30 AM" src="https://github.com/user-attachments/assets/2c61b546-cf88-483c-8da4-87247e76ee13" />
