### PR TITLE
bug: DSD-159 Fix step 1 work order form disabled when forgetting a field 

### DIFF
--- a/src/components/schedule/schedule-work-order-form.tsx
+++ b/src/components/schedule/schedule-work-order-form.tsx
@@ -39,7 +39,6 @@ export default function ScheduleWorkOrderForm({
   const [isLoading, setIsLoading] = useState(false);
   const [serviceTypes, setServiceTypes] = useState<ServiceType[]>([]);
   const [isDisabled, setIsDisabled] = useState(true);
-  const [isNextDisabled, setIsNextDisabled] = useState(false);
   const [backgroundEvents, setBackgroundEvents] = useState<BackgroundEvent[]>(
     [],
   );
@@ -128,14 +127,12 @@ export default function ScheduleWorkOrderForm({
 
   const nextStep = async () => {
     if (step === 1) {
-      const isValid = await trigger(["departmentId", "serviceTypeId"]);
-      if (!isValid) {
+      const isValidStep = await trigger(["departmentId", "serviceTypeId"]);
+      if (!isValidStep) {
         toast.error("Please fill out all fields.");
-        setIsNextDisabled(true);
-      } else {
-        setIsNextDisabled(false);
-        setStep(2);
+        return;
       }
+      setStep(2);
     }
     if (step === 2) {
       if (getValues("appointmentStart") && getValues("appointmentEnd")) {
@@ -268,7 +265,6 @@ export default function ScheduleWorkOrderForm({
             isDisabled={isDisabled}
             setAllTimeslots={setAllTimeslots}
             nextStep={nextStep}
-            isNextDisabled={isNextDisabled}
             setValue={setValue}
           />
         )}
@@ -300,7 +296,6 @@ export default function ScheduleWorkOrderForm({
             userProfile={userProfile}
             setSelectedAddress={setSelectedAddress}
             selectedAddress={selectedAddress}
-            isNextDisabled={isNextDisabled}
             prevStep={prevStep}
             nextStep={nextStep}
           />
@@ -314,7 +309,6 @@ export default function ScheduleWorkOrderForm({
             userProfile={userProfile}
             prevStep={prevStep}
             nextStep={nextStep}
-            isNextDisabled={isNextDisabled}
           />
         )}
         {step === 6 && (

--- a/src/components/schedule/step-1-work-order-form.tsx
+++ b/src/components/schedule/step-1-work-order-form.tsx
@@ -20,7 +20,6 @@ interface Step1DepartmentServiceProps {
   isDisabled: boolean;
   setAllTimeslots: React.Dispatch<React.SetStateAction<Timeslot[]>>;
   nextStep: () => void;
-  isNextDisabled: boolean;
   setValue: UseFormSetValue<CreateWorkOrderInput>;
 }
 
@@ -35,7 +34,6 @@ export default function Step1DepartmentService({
   isDisabled,
   setAllTimeslots,
   nextStep,
-  isNextDisabled,
   setValue,
 }: Step1DepartmentServiceProps) {
   const handleDepartmentSelect = async (
@@ -127,11 +125,7 @@ export default function Step1DepartmentService({
         <Button type="button" onClick={handleReset} className="bg-blue-800">
           Reset
         </Button>
-        <StepButtons
-          variant="nextOnly"
-          nextStep={nextStep}
-          isNextDisabled={isNextDisabled}
-        />
+        <StepButtons variant="nextOnly" nextStep={nextStep} />
       </div>
     </div>
   );

--- a/src/components/schedule/step-4-work-order-form.tsx
+++ b/src/components/schedule/step-4-work-order-form.tsx
@@ -13,7 +13,6 @@ interface Step4SelectAddressProps {
   selectedAddress: "onFile" | "new";
   prevStep: () => void;
   nextStep: () => void;
-  isNextDisabled: boolean;
   userProfile: PartialProfile;
 }
 
@@ -23,7 +22,6 @@ export default function Step4SelectAddress({
   prevStep,
   nextStep,
   userProfile,
-  isNextDisabled,
 }: Step4SelectAddressProps) {
   return (
     <div className="flex flex-col items-center">
@@ -81,7 +79,6 @@ export default function Step4SelectAddress({
             variant="prevNext"
             prevStep={prevStep}
             nextStep={nextStep}
-            isNextDisabled={isNextDisabled}
           />
         </div>
       </div>

--- a/src/components/schedule/step-5-work-order-form.tsx
+++ b/src/components/schedule/step-5-work-order-form.tsx
@@ -15,7 +15,6 @@ interface Step5ContactInformationProps {
   selectedAddress: "onFile" | "new";
   prevStep: () => void;
   nextStep: () => void;
-  isNextDisabled: boolean;
   userProfile: PartialProfile;
 }
 
@@ -26,7 +25,6 @@ export default function Step5ContactInformation({
   prevStep,
   nextStep,
   userProfile,
-  isNextDisabled,
 }: Step5ContactInformationProps) {
   return (
     <div className="flex flex-col items-center">
@@ -152,7 +150,6 @@ export default function Step5ContactInformation({
             variant="prevNext"
             prevStep={prevStep}
             nextStep={nextStep}
-            isNextDisabled={isNextDisabled}
           />
         </div>
       </div>

--- a/src/components/schedule/step-buttons.tsx
+++ b/src/components/schedule/step-buttons.tsx
@@ -6,37 +6,23 @@ interface StepButtonProps {
   variant: "prevOnly" | "prevNext" | "nextOnly";
   prevStep?: () => void;
   nextStep?: () => void;
-  isBackDisabled?: boolean;
-  isNextDisabled?: boolean;
 }
 
 export default function StepButtons({
   variant,
   prevStep,
   nextStep,
-  isBackDisabled,
-  isNextDisabled,
 }: StepButtonProps) {
   return (
     <div className="flex justify-between gap-10">
       {(variant === "prevOnly" || variant === "prevNext") && (
-        <Button
-          type="button"
-          onClick={prevStep}
-          variant="default"
-          disabled={isBackDisabled}
-        >
+        <Button type="button" onClick={prevStep} variant="default">
           <FontAwesomeIcon icon={faArrowLeft} />
           Back
         </Button>
       )}
       {(variant === "nextOnly" || variant === "prevNext") && (
-        <Button
-          type="button"
-          onClick={nextStep}
-          variant="default"
-          disabled={isNextDisabled}
-        >
+        <Button type="button" onClick={nextStep} variant="default">
           Next
           <FontAwesomeIcon icon={faArrowRight} />
         </Button>


### PR DESCRIPTION
# [FE] [DSD-159](https://jarrod-van-doren.atlassian.net/browse/DSD-159?atlOrigin=eyJpIjoiYmQ0NDczYzIwYzI2NDQ1ZDgwY2Y1MmU1OTk0MmQ0ZGMiLCJwIjoiaiJ9) Fix step 1 work order form next button disabled when forgetting a field

## Summary
This PR implements a bug fix for step 1 of the work order form. Previously if a user forgot to fill out a field, the next button was disabled. Without resetting this state, it would not allow a user to proceed in the form.

## Changes
The `isNextDisabled` state is removed from the form and from all work order form components and the `StepButton` component. Adding a `return` to the validation check helps get out of the validation. Toast errors still trigger properly when a user forgets one field or both.