### PR TITLE
bug:  (DSD-161) Fix work order conditional display

### DIFF
--- a/src/app/(main)/admin/work-orders/page.tsx
+++ b/src/app/(main)/admin/work-orders/page.tsx
@@ -15,17 +15,19 @@ export default async function Page() {
   if (!profile) notFound();
 
   return (
-    <div className="px-4 py-12">
-      <div className="mx-10 flex items-center justify-between gap-2 pb-4">
-        <h1 className="text-3xl font-bold tracking-tight">
-          Manage Work Orders
-        </h1>
-        <Button asLink href="/dashboard">
-          <FontAwesomeIcon icon={faLeftLong} />
-        </Button>
+    <div className="container mx-auto space-y-4 px-2 py-12">
+      <div className="px-2 md:px-4 lg:px-10">
+        <div className="flex items-center justify-between gap-2 pb-4">
+          <h1 className="text-3xl font-bold tracking-tight">
+            Manage Work Orders
+          </h1>
+          <Button asLink href="/dashboard">
+            <FontAwesomeIcon icon={faLeftLong} />
+          </Button>
+        </div>
+        <div className="bg-muted mb-4 h-1" />
+        <WorkOrderList />
       </div>
-      <div className="bg-muted mx-10 h-1" />
-      <WorkOrderList />
     </div>
   );
 }

--- a/src/components/dashboard/admin-dashboard.tsx
+++ b/src/components/dashboard/admin-dashboard.tsx
@@ -56,7 +56,7 @@ const links = [
 ];
 export const AdminDashboard = () => {
   return (
-    <div className="container mx-auto space-y-4 px-4 py-12">
+    <div className="container mx-auto space-y-4 px-2 py-12">
       <h1 className="text-3xl font-bold tracking-tight">Admin Dashboard</h1>
       <div className="bg-muted h-1" />
 

--- a/src/components/dashboard/client-dashboard.tsx
+++ b/src/components/dashboard/client-dashboard.tsx
@@ -3,23 +3,23 @@ import { Button } from "../ui/button";
 
 export const ClientDashboard = () => {
   return (
-    <div className="m-0 py-12 md:m-2 md:m-4">
-      <div className="px-4 lg:px-10">
+    <div className="container mx-auto space-y-4 px-2 py-12">
+      <div className="px-2 md:px-4 lg:px-10">
         <h1 className="text-3xl font-bold tracking-tight">Dashboard</h1>
         <div className="bg-muted h-1" />
+        <h2 className="pt-2 text-xl font-semibold text-blue-800">
+          Schedule Appointment
+        </h2>
+        <div className="m-0 flex flex-col items-center gap-2 rounded-none bg-blue-50 p-2 py-3 text-xs md:mb-3 md:gap-3 md:rounded-lg md:p-3 lg:mb-4 lg:p-4">
+          <Button asLink href="/schedule">
+            Schedule an appointment now
+          </Button>
+        </div>
+        <h2 className="pt-4 text-xl font-semibold text-blue-800">
+          Appointments
+        </h2>
+        <WorkOrderList />
       </div>
-      <h2 className="pt-2 pl-4 text-xl font-semibold text-blue-800 lg:pl-10">
-        Schedule Appointment
-      </h2>
-      <div className="m-0 flex flex-col items-center gap-2 rounded-none bg-blue-50 p-2 text-xs md:m-2 md:mx-2 md:mb-3 md:gap-3 md:rounded-lg md:p-3 lg:mx-10 lg:mb-4 lg:p-4">
-        <Button asLink href="/schedule">
-          Schedule an appointment now
-        </Button>
-      </div>
-      <h2 className="pt-4 pl-4 text-xl font-semibold text-blue-800 lg:pl-10">
-        Appointments
-      </h2>
-      <WorkOrderList />
     </div>
   );
 };

--- a/src/components/dashboard/technician-dashboard.tsx
+++ b/src/components/dashboard/technician-dashboard.tsx
@@ -3,19 +3,19 @@ import TechnicianCalendar from "@/features/technician-details/components/tech-ca
 
 export default function TechnicianDashboard() {
   return (
-    <div className="m-2 md:m-4">
-      <div className="px-10">
+    <div className="container mx-auto space-y-4 px-2 py-12">
+      <div className="px-2 md:px-4 lg:px-10">
         <h1 className="text-3xl font-bold tracking-tight">Dashboard</h1>
         <div className="bg-muted h-1" />
+        <h2 className="pt-4 text-xl font-semibold text-blue-800">
+          Your Work Orders
+        </h2>
+        <WorkOrderList />
+        <h2 className="pt-4 text-xl font-semibold text-blue-800">
+          Your Schedule
+        </h2>
+        <TechnicianCalendar />
       </div>
-      <h2 className="pt-4 pl-10 text-xl font-semibold text-blue-800">
-        Your Work Orders
-      </h2>
-      <WorkOrderList />
-      <h2 className="pt-2 pl-10 text-xl font-semibold text-blue-800">
-        Your Schedule
-      </h2>
-      <TechnicianCalendar />
     </div>
   );
 }

--- a/src/features/dashboard/components/update-appt-notes-dialog.tsx
+++ b/src/features/dashboard/components/update-appt-notes-dialog.tsx
@@ -6,7 +6,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { Button } from "@/components/ui/button";
 import { useDialog } from "@/components/ui/use-dialog";
 import { Dialog } from "@/components/ui/dialog";
-import { UpdateApptNotesForm } from "../update-appt-notes-form";
+import { UpdateApptNotesForm } from "./update-appt-notes-form";
 
 type UpdateApptNotesDialogProps = { workOrder: HydratedWorkOrder };
 

--- a/src/features/dashboard/components/update-appt-notes-form.tsx
+++ b/src/features/dashboard/components/update-appt-notes-form.tsx
@@ -7,11 +7,11 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { toast } from "react-hot-toast";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
+import { updateApptNotes } from "@/features/work-orders/actions/update-appt-notes.action";
 import {
   ApptNotesInput,
   ApptNotesSchema,
-} from "../technician-details/components/schemas";
-import { updateApptNotes } from "@/features/work-orders/actions/update-appt-notes.action";
+} from "@/features/technician-details/components/schemas";
 
 type UpdateApptNotesFormProps = {
   workOrder: HydratedWorkOrder;

--- a/src/features/dashboard/components/work-order-card.tsx
+++ b/src/features/dashboard/components/work-order-card.tsx
@@ -85,11 +85,11 @@ export default function WorkOrderCard({
     workOrder.missing_parts.length > 0;
 
   return (
-    <div className="bg-background w-full gap-2 rounded-md p-2 shadow-lg md:gap-3 md:p-3 lg:p-4 lg:pb-2">
+    <div className="bg-background w-full max-w-[1050px] gap-2 rounded-md p-4 shadow-lg sm:pr-10 md:pr-4">
       <div className="flex flex-row justify-between">
         <div className="flex w-full flex-col md:flex-row">
           <div className="mr-4 flex md:mr-0">
-            <div className="mr-4 w-1/2 md:mr-10 md:min-w-[180px] lg:min-w-[220px]">
+            <div className="mr-2 w-1/2 md:mr-4 md:w-1/3 md:min-w-[150px] lg:mr-10 lg:w-1/2 lg:min-w-[180px] lg:min-w-[220px]">
               <WorkOrderGroup labelText="Date &amp; Time">
                 {workOrder.appointment_start ? (
                   <>
@@ -107,7 +107,7 @@ export default function WorkOrderCard({
                 ) : null}
               </WorkOrderGroup>
             </div>
-            <div className="w-1/2 flex-grow md:mr-10 md:min-w-[270px] lg:min-w-[290px]">
+            <div className="w-1/2 flex-grow md:mr-2 md:w-1/3 md:min-w-[220px] lg:mr-10 lg:w-1/2 lg:min-w-[290px]">
               <WorkOrderGroup labelText="Service Dept. &amp; Type">
                 <span>{workOrder.department.name}:</span>{" "}
                 <span className="block lg:inline">
@@ -117,7 +117,7 @@ export default function WorkOrderCard({
             </div>
           </div>
           <div className="mt-3 mr-4 flex flex-grow flex-row md:mt-0 md:mr-4 md:flex-wrap lg:flex-row">
-            <div className="mr-4 w-1/2 md:mr-0 md:mb-3 md:w-full md:max-w-[100px] lg:mr-16">
+            <div className="mr-1 w-1/2 md:mr-4 md:mb-3 md:w-full md:max-w-[100px] lg:mr-16">
               <WorkOrderGroup labelText="Technician">
                 <div className="flex items-center">
                   <span>
@@ -127,7 +127,7 @@ export default function WorkOrderCard({
                 </div>
               </WorkOrderGroup>
             </div>
-            <div className="flex w-1/2">
+            <div className="flex w-1/2 sm:w-1/3 md:w-1/2">
               <WorkOrderGroup labelText="Status">
                 {" "}
                 {workOrder.status.toLocaleUpperCase()}
@@ -153,7 +153,7 @@ export default function WorkOrderCard({
               </Tooltip>
             )}
           <span
-            className="ml-auto cursor-pointer pr-2 text-right text-xl font-medium text-blue-500"
+            className="ml-auto cursor-pointer pr-2 text-right text-xl font-medium text-blue-500 sm:pl-4"
             onClick={() => setIsExpanded(!isExpanded)}
           >
             <motion.span

--- a/src/features/dashboard/components/work-order-list-admin.tsx
+++ b/src/features/dashboard/components/work-order-list-admin.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, Fragment } from "react";
 import { Select } from "@/components/ui/select";
 import { HydratedWorkOrder } from "@/utils/supabase/types";
 import WorkOrderCard from "./work-order-card";
@@ -64,13 +64,11 @@ export default function WorkOrderListAdmin({
           </h3>
           {todayAppointments.length > 0 ? (
             todayAppointments.map((workOrder) => (
-              <>
-                <WorkOrderCard
-                  key={workOrder.id}
-                  workOrder={workOrder}
-                  userRole={userRole}
-                />
-              </>
+              <WorkOrderCard
+                key={workOrder.id}
+                workOrder={workOrder}
+                userRole={userRole}
+              />
             ))
           ) : (
             <div>

--- a/src/features/dashboard/components/work-order-list.tsx
+++ b/src/features/dashboard/components/work-order-list.tsx
@@ -153,21 +153,45 @@ export default async function WorkOrderList() {
           ))}
         </>
       )}
-      {(userRole === "CLIENT" || userRole === "TECHNICIAN") && (
+      {userRole === "CLIENT" && (
         <>
-          {userRole === "CLIENT" ? (
-            <h3 className="text-lg font-bold text-blue-800">
-              Upcoming Appointments:
-            </h3>
+          <h3 className="mt-6 text-lg font-bold text-blue-800">
+            Upcoming Appointments:
+          </h3>
+          {upcomingAppointments?.length > 0 ? (
+            <PaginationWrapper
+              userRole={userRole}
+              appointments={upcomingAppointments}
+            />
           ) : (
-            <h3 className="mt-6 text-lg font-bold text-blue-800">
-              Upcoming Work Orders:
-            </h3>
+            <div className="flex flex-col">
+              <span className="text-center text-base text-slate-700 lg:text-lg">
+                You don&apos;t have any upcoming appointments.
+              </span>
+              <span className="text-center text-base text-slate-700 lg:text-lg">
+                Schedule a new appointment above!
+              </span>
+            </div>
           )}
-          <PaginationWrapper
-            userRole={userRole}
-            appointments={upcomingAppointments}
-          />
+        </>
+      )}
+      {userRole === "TECHNICIAN" && (
+        <>
+          <h3 className="mt-6 text-lg font-bold text-blue-800">
+            Upcoming Work Orders:
+          </h3>
+          {upcomingAppointments?.length > 0 ? (
+            <PaginationWrapper
+              userRole={userRole}
+              appointments={upcomingAppointments}
+            />
+          ) : (
+            <div>
+              <span className="text-center text-base text-slate-700 lg:text-lg">
+                You have no upcoming work orders.
+              </span>
+            </div>
+          )}
         </>
       )}
       {userRole === "CLIENT" && pastAppointments.length > 0 && (

--- a/src/features/dashboard/components/work-order-list.tsx
+++ b/src/features/dashboard/components/work-order-list.tsx
@@ -109,7 +109,7 @@ export default async function WorkOrderList() {
   });
 
   return (
-    <div className="m-0 flex flex-col items-center gap-2 rounded-none bg-blue-50 p-2 text-xs md:m-2 md:mx-2 md:mb-3 md:gap-3 md:rounded-lg md:p-3 lg:mx-10 lg:mb-4 lg:p-4">
+    <div className="m-0 flex flex-col items-center gap-2 rounded-none bg-blue-50 p-3 text-xs sm:gap-3 md:rounded-lg">
       {userRole === "ADMIN" && (
         <WorkOrderListAdmin
           todayAppointments={todayAppointments}
@@ -117,12 +117,10 @@ export default async function WorkOrderList() {
           userRole={userRole}
         />
       )}
-      {(userRole === "TECHNICIAN" || userRole === "CLIENT") && (
+      {userRole === "TECHNICIAN" && (
         <>
           <h3 className="text-lg font-bold text-blue-800">
-            Today&apos;s{" "}
-            {userRole === "CLIENT" ? "Appointments" : "Work Orders"} -{" "}
-            {today.toLocaleString()}:
+            Today&apos;s Work Orders - {today.toLocaleString()}:
           </h3>
           {todayAppointments.length > 0 ? (
             todayAppointments.map((workOrder) => (
@@ -132,34 +130,33 @@ export default async function WorkOrderList() {
                 userRole={userRole}
               />
             ))
-          ) : userRole === "TECHNICIAN" ? (
+          ) : (
             <div>
               <span className="text-center text-base text-slate-700 lg:text-lg">
                 You have no work orders scheduled today.
               </span>
             </div>
-          ) : userRole === "CLIENT" ? (
-            <div className="flex flex-col">
-              <span className="text-center text-base text-slate-700 lg:text-lg">
-                You don&apos;t have any upcoming appointments.
-              </span>
-              <span className="text-center text-base text-slate-700 lg:text-lg">
-                Schedule a new appointment above!
-              </span>
-            </div>
-          ) : (
-            <div>
-              <span className="text-center text-base text-slate-700 lg:text-lg">
-                No work orders are scheduled today.
-              </span>
-            </div>
           )}
+        </>
+      )}
+      {userRole === "CLIENT" && todayAppointments?.length > 0 && (
+        <>
+          <h3 className="text-lg font-bold text-blue-800">
+            Today&apos;s Appointments - {today.toLocaleString()}:
+          </h3>
+          {todayAppointments.map((appointment) => (
+            <WorkOrderCard
+              key={appointment.id}
+              workOrder={appointment}
+              userRole={userRole}
+            />
+          ))}
         </>
       )}
       {(userRole === "CLIENT" || userRole === "TECHNICIAN") && (
         <>
           {userRole === "CLIENT" ? (
-            <h3 className="mt-6 text-lg font-bold text-blue-800">
+            <h3 className="text-lg font-bold text-blue-800">
               Upcoming Appointments:
             </h3>
           ) : (


### PR DESCRIPTION
# [FE] [DSD-161](https://jarrod-van-doren.atlassian.net/browse/DSD-161?atlOrigin=eyJpIjoiNTBmMDc2YTJkZWM3NGI2ZGJmNmQ4OThmNGExZmVmYzUiLCJwIjoiaiJ9) Fix work order conditional Display & [DSD-160](https://jarrod-van-doren.atlassian.net/browse/DSD-160?atlOrigin=eyJpIjoiZTJhODdjYTE0YWVjNDkwZjkwMGJhN2FlNGIyM2ViYjciLCJwIjoiaiJ9) Fix work order card width on large screens

## Summary
This PR implements adjustments to conditional rendering in the work order list, style adjustments to work order card widths, and a fix to an error of a unique key prop missing.

## Changes

### Client Dashboard now only displays today's appointments if there are any, otherwise the default is Upcoming Appointments.

Before:
<img width="1103" alt="Screenshot 2025-03-21 at 10 39 56 PM" src="https://github.com/user-attachments/assets/be8f8eae-6b3c-4583-9d97-8bb9554308be" />

After:
<img width="1471" alt="Screenshot 2025-03-21 at 10 34 41 PM" src="https://github.com/user-attachments/assets/019adbfb-3e55-4cf2-b36b-e2b2a9b87e86" />


### Container added around work order list and max width set for work order card

Before:
<img width="1512" alt="Screenshot 2025-03-21 at 10 39 10 PM" src="https://github.com/user-attachments/assets/d91f8f6b-d75c-4ca4-a389-c71a4bc23f0b" />

After:
<img width="1103" alt="Screenshot 2025-03-21 at 10 39 56 PM" src="https://github.com/user-attachments/assets/c514fa09-f4ab-4ecb-818a-480d5a790137" />
