### PR TITLE
bug: (DSD-165) Work order timeslot no click

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@fullcalendar/core": "^6.1.15",
         "@fullcalendar/daygrid": "^6.1.15",
         "@fullcalendar/interaction": "^6.1.15",
+        "@fullcalendar/luxon3": "^6.1.15",
         "@fullcalendar/react": "^6.1.15",
         "@fullcalendar/timegrid": "^6.1.15",
         "@hookform/resolvers": "^4.1.3",
@@ -271,6 +272,16 @@
       "license": "MIT",
       "peerDependencies": {
         "@fullcalendar/core": "~6.1.15"
+      }
+    },
+    "node_modules/@fullcalendar/luxon3": {
+      "version": "6.1.15",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/luxon3/-/luxon3-6.1.15.tgz",
+      "integrity": "sha512-+T3JXZw6C6qmnSiPUuTd3MonTxC6mBsqpJxL+eLX6Vo7YkeBtM9tIdpN1gOL+ICQXq33tWcKPTCSzTlXRz+hmA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@fullcalendar/core": "~6.1.15",
+        "luxon": "^3.0.0"
       }
     },
     "node_modules/@fullcalendar/react": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@fullcalendar/core": "^6.1.15",
     "@fullcalendar/daygrid": "^6.1.15",
     "@fullcalendar/interaction": "^6.1.15",
+    "@fullcalendar/luxon3": "^6.1.15",
     "@fullcalendar/react": "^6.1.15",
     "@fullcalendar/timegrid": "^6.1.15",
     "@hookform/resolvers": "^4.1.3",

--- a/src/components/schedule/lib/work-order-queries.ts
+++ b/src/components/schedule/lib/work-order-queries.ts
@@ -7,8 +7,7 @@ export const fetchServiceTypes = async (departmentId: string) => {
   const { data, error } = await supabase
     .from("department_service_types")
     .select("service_types(*)")
-    .eq("department_id", +departmentId)
-    .order("service_types->name", { ascending: true });
+    .eq("department_id", +departmentId);
 
   if (error) {
     return { data: null, error: "Failed to find service types" };

--- a/src/components/schedule/schedule-work-order-calendar.tsx
+++ b/src/components/schedule/schedule-work-order-calendar.tsx
@@ -1,4 +1,5 @@
 import FullCalendar from "@fullcalendar/react";
+import luxonPlugin from "@fullcalendar/luxon3";
 import dayGridPlugin from "@fullcalendar/daygrid";
 import interactionPlugin from "@fullcalendar/interaction";
 import { EventClickArg } from "@fullcalendar/core/index.js";
@@ -18,7 +19,8 @@ export default function ScheduleWorkOrderCalendar({
 }: ScheduleWorkOrderCalendarProps) {
   return (
     <FullCalendar
-      plugins={[dayGridPlugin, interactionPlugin]}
+      timeZone="America/Denver"
+      plugins={[luxonPlugin, dayGridPlugin, interactionPlugin]}
       eventSources={[
         {
           events: backgroundEvents,
@@ -26,6 +28,7 @@ export default function ScheduleWorkOrderCalendar({
           backgroundColor: "#05df72",
         },
       ]}
+      titleFormat={"LLLL yyyy"}
       initialView="dayGridMonth"
       validRange={(currentDate) => {
         const startDate = new Date(currentDate.valueOf());

--- a/src/components/schedule/step-2-work-order-form.tsx
+++ b/src/components/schedule/step-2-work-order-form.tsx
@@ -67,8 +67,6 @@ export default function Step2SelectDateTime({
     }).toISODate();
     const todayDate = DateTime.now().setZone("America/Denver").toISODate();
 
-    console.log("Clicked Date:", clickedDate);
-
     setTodaySelected(clickedDate === todayDate);
 
     const slots = allTimeslots.filter((slot: Timeslot) => {
@@ -114,8 +112,6 @@ export default function Step2SelectDateTime({
 
     setValue("appointmentStart", slot.start);
     setValue("appointmentEnd", slot.end);
-    console.log("Appointment Start", slot.start);
-    console.log("Appintment end:", slot.end);
 
     setIsTimeslotModalOpen(false);
     setIsProcessing(false);

--- a/src/components/schedule/timeslot-list.tsx
+++ b/src/components/schedule/timeslot-list.tsx
@@ -20,7 +20,10 @@ export default function TimeslotList({
         <li
           key={slot.id}
           className="mx-4 my-2 cursor-pointer rounded bg-blue-100 p-2 text-black hover:bg-blue-300"
-          onClick={() => handleSelectSlot(slot)}
+          onClick={(e) => {
+            e.stopPropagation();
+            handleSelectSlot(slot);
+          }}
         >
           {new Date(slot.start).toLocaleTimeString([], {
             hour: "2-digit",


### PR DESCRIPTION
# [FE] [DSD-165](https://jarrod-van-doren.atlassian.net/browse/DSD-165?atlOrigin=eyJpIjoiNTY1ODI0NDRhZmJhNDdiZDk3YzY4MWUyM2IyMTViY2MiLCJwIjoiaiJ9) Bug: Work order timeslot progresses without clicking 

## Summary 
This PR implements a bug fix for the issue of a likely event propagation in Step 2 of the work order form that resulted in clicking on a date and moving to step 3 without selecting a timeslot as the click was likely passing to the modal and selecting a slot automatically.

## Changes
(While starting on the time sync, I kept running into this issue, so some of the changes below were dealing with the timezone, and some were dealing with the event propagation issue. The timezone issues will be further solved in another PR)

- Install Luxon 3 
- Use Luxon on Calendar
- Use Luxon in `handleEventClick` function in Step 2 of work order form
- Add `isProcessing` state to Step 2 of work order form to help handle the state of the date selection and slot selection in step 2 to prevent it from progressing to Step 3 before all of the actions are completed.
- Add `e.stopPropagation()` to the `onClick` in the `timelist-slot` component to try to help handle any bubbling up of click events

Before:

https://github.com/user-attachments/assets/4f6f24b8-6752-406c-bb11-3ae0f0fa904c

After (Clicking on March 28th towards the end that is quick was an accidental double-click):

https://github.com/user-attachments/assets/a64021db-e170-4ba9-bf0f-ec3da69133ef
