### PR TITLE
fix: Remove commas when there is no address

### DIFF
--- a/src/app/(main)/account/page.tsx
+++ b/src/app/(main)/account/page.tsx
@@ -89,13 +89,34 @@ export default async function Page() {
               />
               <div>
                 <p className="text-sm font-medium text-gray-500">Address</p>
-                <p className="font-medium text-gray-800">
-                  {profile.address_line1}
-                  {profile.address_line2 && `, ${profile.address_line2}`}
-                </p>
-                <p className="font-medium text-gray-800">
-                  {profile.city}, {profile.state} {profile.postal_code}
-                </p>
+                {profile.address_line1 ||
+                profile.city ||
+                profile.state ||
+                profile.postal_code ? (
+                  <>
+                    {profile.address_line1 && (
+                      <p className="font-medium text-gray-800">
+                        {profile.address_line1}
+                        {profile.address_line2
+                          ? `, ${profile.address_line2}`
+                          : ""}
+                      </p>
+                    )}
+                    {(profile.city || profile.state || profile.postal_code) && (
+                      <p className="font-medium text-gray-800">
+                        {profile.city}
+                        {profile.city && profile.state ? ", " : ""}
+                        {profile.state}
+                        {(profile.city || profile.state) && profile.postal_code
+                          ? " "
+                          : ""}
+                        {profile.postal_code}
+                      </p>
+                    )}
+                  </>
+                ) : (
+                  <p className="text-gray-500 italic">Address not provided</p>
+                )}
               </div>
             </div>
 


### PR DESCRIPTION
## DSD-167 Account page remove comma if no address

### Changes 

- Improved logic to correctly place commas only when necessary in the address display.
- Added a clear fallback message when no address is provided .