### PR TITLE
Bug&Feat (DSD-80, DSD-163 & DSD-165) Timezones & Fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@fullcalendar/core": "^6.1.15",
         "@fullcalendar/daygrid": "^6.1.15",
         "@fullcalendar/interaction": "^6.1.15",
+        "@fullcalendar/luxon3": "^6.1.15",
         "@fullcalendar/react": "^6.1.15",
         "@fullcalendar/timegrid": "^6.1.15",
         "@hookform/resolvers": "^4.1.3",
@@ -271,6 +272,16 @@
       "license": "MIT",
       "peerDependencies": {
         "@fullcalendar/core": "~6.1.15"
+      }
+    },
+    "node_modules/@fullcalendar/luxon3": {
+      "version": "6.1.15",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/luxon3/-/luxon3-6.1.15.tgz",
+      "integrity": "sha512-+T3JXZw6C6qmnSiPUuTd3MonTxC6mBsqpJxL+eLX6Vo7YkeBtM9tIdpN1gOL+ICQXq33tWcKPTCSzTlXRz+hmA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@fullcalendar/core": "~6.1.15",
+        "luxon": "^3.0.0"
       }
     },
     "node_modules/@fullcalendar/react": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@fullcalendar/core": "^6.1.15",
     "@fullcalendar/daygrid": "^6.1.15",
     "@fullcalendar/interaction": "^6.1.15",
+    "@fullcalendar/luxon3": "^6.1.15",
     "@fullcalendar/react": "^6.1.15",
     "@fullcalendar/timegrid": "^6.1.15",
     "@hookform/resolvers": "^4.1.3",

--- a/src/components/header/nav-items.ts
+++ b/src/components/header/nav-items.ts
@@ -13,14 +13,14 @@ export interface NavDataItem {
 
 export const navItems: NavDataItem[] = [
   {
-    label: "Account",
-    href: "/account",
-    icon: faUser,
-  },
-  {
     label: "Dashboard",
     href: "/dashboard",
     icon: faDashboard,
+  },
+  {
+    label: "Account",
+    href: "/account",
+    icon: faUser,
   },
 ];
 

--- a/src/components/schedule/lib/work-order-queries.ts
+++ b/src/components/schedule/lib/work-order-queries.ts
@@ -7,8 +7,7 @@ export const fetchServiceTypes = async (departmentId: string) => {
   const { data, error } = await supabase
     .from("department_service_types")
     .select("service_types(*)")
-    .eq("department_id", +departmentId)
-    .order("service_types->name", { ascending: true });
+    .eq("department_id", +departmentId);
 
   if (error) {
     return { data: null, error: "Failed to find service types" };

--- a/src/components/schedule/schedule-work-order-calendar.tsx
+++ b/src/components/schedule/schedule-work-order-calendar.tsx
@@ -1,4 +1,5 @@
 import FullCalendar from "@fullcalendar/react";
+import luxonPlugin from "@fullcalendar/luxon3";
 import dayGridPlugin from "@fullcalendar/daygrid";
 import interactionPlugin from "@fullcalendar/interaction";
 import { EventClickArg } from "@fullcalendar/core/index.js";
@@ -18,7 +19,8 @@ export default function ScheduleWorkOrderCalendar({
 }: ScheduleWorkOrderCalendarProps) {
   return (
     <FullCalendar
-      plugins={[dayGridPlugin, interactionPlugin]}
+      timeZone="America/Denver"
+      plugins={[luxonPlugin, dayGridPlugin, interactionPlugin]}
       eventSources={[
         {
           events: backgroundEvents,
@@ -26,6 +28,7 @@ export default function ScheduleWorkOrderCalendar({
           backgroundColor: "#05df72",
         },
       ]}
+      titleFormat={"LLLL yyyy"}
       initialView="dayGridMonth"
       validRange={(currentDate) => {
         const startDate = new Date(currentDate.valueOf());

--- a/src/components/schedule/schedule-work-order-form.tsx
+++ b/src/components/schedule/schedule-work-order-form.tsx
@@ -1,5 +1,4 @@
 "use client";
-// TODO -- display dates in user timezone
 
 import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
@@ -81,7 +80,6 @@ export default function ScheduleWorkOrderForm({
       },
     },
   });
-
   useEffect(() => {
     const backgroundEvents = groupTimeslotsByDay(allTimeslots);
     setBackgroundEvents(backgroundEvents);

--- a/src/components/schedule/step-2-work-order-form.tsx
+++ b/src/components/schedule/step-2-work-order-form.tsx
@@ -67,8 +67,6 @@ export default function Step2SelectDateTime({
     }).toISODate();
     const todayDate = DateTime.now().setZone("America/Denver").toISODate();
 
-    console.log("Clicked Date:", clickedDate);
-
     setTodaySelected(clickedDate === todayDate);
 
     const slots = allTimeslots.filter((slot: Timeslot) => {
@@ -114,8 +112,6 @@ export default function Step2SelectDateTime({
 
     setValue("appointmentStart", slot.start);
     setValue("appointmentEnd", slot.end);
-    console.log("Appointment Start", slot.start);
-    console.log("Appintment end:", slot.end);
 
     setIsTimeslotModalOpen(false);
     setIsProcessing(false);

--- a/src/components/schedule/step-2-work-order-form.tsx
+++ b/src/components/schedule/step-2-work-order-form.tsx
@@ -67,8 +67,6 @@ export default function Step2SelectDateTime({
     }).toISODate();
     const todayDate = DateTime.now().setZone("America/Denver").toISODate();
 
-    console.log("Clicked Date:", clickedDate);
-
     setTodaySelected(clickedDate === todayDate);
 
     const slots = allTimeslots.filter((slot: Timeslot) => {

--- a/src/components/schedule/step-2-work-order-form.tsx
+++ b/src/components/schedule/step-2-work-order-form.tsx
@@ -67,6 +67,8 @@ export default function Step2SelectDateTime({
     }).toISODate();
     const todayDate = DateTime.now().setZone("America/Denver").toISODate();
 
+    console.log("Clicked Date:", clickedDate);
+
     setTodaySelected(clickedDate === todayDate);
 
     const slots = allTimeslots.filter((slot: Timeslot) => {
@@ -82,7 +84,10 @@ export default function Step2SelectDateTime({
     });
 
     const sortedSlots = slots.sort((a, b) => {
-      return new Date(a.start).getTime() - new Date(b.start).getTime();
+      return (
+        DateTime.fromISO(a.start).setZone("America/Denver").toMillis() -
+        DateTime.fromISO(b.start).setZone("America/Denver").toMillis()
+      );
     });
 
     setSelectedDate(
@@ -110,8 +115,26 @@ export default function Step2SelectDateTime({
 
     setIsProcessing(true);
 
-    setValue("appointmentStart", slot.start);
-    setValue("appointmentEnd", slot.end);
+    const startDateTime = DateTime.fromISO(slot.start).setZone(
+      "America/Denver",
+    );
+    const endDateTime = DateTime.fromISO(slot.end).setZone("America/Denver");
+
+    if (!startDateTime.isValid || !endDateTime.isValid) {
+      console.error(
+        "Invalid datetime selected:",
+        startDateTime.invalidExplanation,
+        endDateTime.invalidExplanation,
+      );
+      setIsProcessing(false);
+      return;
+    }
+
+    const formattedStartUTC = startDateTime.toUTC().toISO();
+    const formattedEndUTC = endDateTime.toUTC().toISO();
+
+    setValue("appointmentStart", formattedStartUTC);
+    setValue("appointmentEnd", formattedEndUTC);
 
     setIsTimeslotModalOpen(false);
     setIsProcessing(false);

--- a/src/components/schedule/step-3-work-order-form.tsx
+++ b/src/components/schedule/step-3-work-order-form.tsx
@@ -1,3 +1,4 @@
+import { DateTime } from "luxon";
 import { formatDateLong } from "@/lib/utils";
 import StepButtons from "./step-buttons";
 import { CreateWorkOrderInput } from "@/features/work-orders/schemas";
@@ -13,6 +14,16 @@ export default function Step3ConfirmDateTime({
   nextStep,
   formValues,
 }: Step3ConfirmDateTimeProps) {
+  const timeZone = "America/Denver";
+
+  const formatTime = (date: Date) => {
+    return DateTime.fromJSDate(date).setZone(timeZone).toFormat("h:mm a");
+  };
+
+  const convertToSetTimeZone = (date: Date) => {
+    return DateTime.fromJSDate(date).setZone(timeZone);
+  };
+
   return (
     <div className="-mt-10 flex flex-col items-center justify-center px-2">
       <h2 className="flex pb-2 text-center text-base font-semibold md:text-lg">
@@ -25,20 +36,15 @@ export default function Step3ConfirmDateTime({
               Selected Time:
             </span>
             <span className="block text-lg font-medium">
-              {formatDateLong(new Date(formValues.appointmentStart))}
+              {formatDateLong(
+                convertToSetTimeZone(
+                  new Date(formValues.appointmentStart),
+                ).toJSDate(),
+              )}
             </span>
             <span className="block text-lg font-medium">
-              {new Date(formValues.appointmentStart).toLocaleTimeString([], {
-                hour: "numeric",
-                minute: "2-digit",
-                hour12: true,
-              })}{" "}
-              -{" "}
-              {new Date(formValues.appointmentEnd).toLocaleTimeString([], {
-                hour: "numeric",
-                minute: "2-digit",
-                hour12: true,
-              })}
+              {formatTime(new Date(formValues.appointmentStart))} -{" "}
+              {formatTime(new Date(formValues.appointmentEnd))}
             </span>
           </div>
           <p className="pt-4 italic">

--- a/src/components/schedule/step-6-work-order-form.tsx
+++ b/src/components/schedule/step-6-work-order-form.tsx
@@ -1,3 +1,4 @@
+import { DateTime } from "luxon";
 import WorkOrderGroup from "../dashboard/work-order-group";
 import { formatDateLong } from "@/lib/utils";
 import StepButtons from "./step-buttons";
@@ -25,6 +26,16 @@ export default function Step6ConfirmAppointment({
   prevStep,
   isSubmitting,
 }: Step6ConfirmAppointmentProps) {
+  const timeZone = "America/Denver";
+
+  const convertToTimeZone = (date: Date) => {
+    return DateTime.fromJSDate(date).setZone(timeZone);
+  };
+
+  const formatTime = (date: Date) => {
+    return DateTime.fromJSDate(date).setZone(timeZone).toFormat("h:mm a");
+  };
+
   return (
     <div>
       <h2 className="pb-2 text-center text-base font-semibold md:text-lg">
@@ -35,20 +46,15 @@ export default function Step6ConfirmAppointment({
         {formValues.appointmentStart && formValues.appointmentEnd && (
           <>
             <span className="block text-center text-sm font-bold text-blue-800 sm:text-base md:text-lg">
-              {formatDateLong(new Date(formValues.appointmentStart))}
+              {formatDateLong(
+                convertToTimeZone(
+                  new Date(formValues.appointmentStart),
+                ).toJSDate(),
+              )}
             </span>
             <span className="block text-center text-sm font-bold text-blue-800 sm:text-base md:text-base md:text-lg">
-              {new Date(formValues.appointmentStart).toLocaleTimeString([], {
-                hour: "numeric",
-                minute: "2-digit",
-                hour12: true,
-              })}{" "}
-              -{" "}
-              {new Date(formValues.appointmentEnd).toLocaleTimeString([], {
-                hour: "numeric",
-                minute: "2-digit",
-                hour12: true,
-              })}
+              {formatTime(new Date(formValues.appointmentStart))} -{" "}
+              {formatTime(new Date(formValues.appointmentEnd))}
             </span>
           </>
         )}

--- a/src/components/schedule/timeslot-list.tsx
+++ b/src/components/schedule/timeslot-list.tsx
@@ -1,3 +1,4 @@
+import { DateTime } from "luxon";
 import { Timeslot } from "@/lib/types/work-order-types";
 
 interface TimeslotListProps {
@@ -11,31 +12,30 @@ export default function TimeslotList({
   filteredSlots,
   handleSelectSlot,
 }: TimeslotListProps) {
+  const timeZone = "America/Denver";
+
   return (
     <ul
       ref={timeslotListRef}
       className="inner-shadow mb-6 max-h-72 overflow-y-auto pb-4"
     >
-      {filteredSlots.map((slot: Timeslot) => (
-        <li
-          key={slot.id}
-          className="mx-4 my-2 cursor-pointer rounded bg-blue-100 p-2 text-black hover:bg-blue-300"
-          onClick={(e) => {
-            e.stopPropagation();
-            handleSelectSlot(slot);
-          }}
-        >
-          {new Date(slot.start).toLocaleTimeString([], {
-            hour: "2-digit",
-            minute: "2-digit",
-          })}{" "}
-          -{" "}
-          {new Date(slot.end).toLocaleTimeString([], {
-            hour: "2-digit",
-            minute: "2-digit",
-          })}
-        </li>
-      ))}
+      {filteredSlots.map((slot: Timeslot) => {
+        const startTime = DateTime.fromISO(slot.start).setZone(timeZone);
+        const endTime = DateTime.fromISO(slot.end).setZone(timeZone);
+
+        return (
+          <li
+            key={slot.id}
+            className="mx-4 my-2 cursor-pointer rounded bg-blue-100 p-2 text-black hover:bg-blue-300"
+            onClick={(e) => {
+              e.stopPropagation();
+              handleSelectSlot(slot);
+            }}
+          >
+            {startTime.toFormat("h:mm a")} - {endTime.toFormat("h:mm a")}
+          </li>
+        );
+      })}
     </ul>
   );
 }

--- a/src/components/schedule/timeslot-list.tsx
+++ b/src/components/schedule/timeslot-list.tsx
@@ -20,7 +20,10 @@ export default function TimeslotList({
         <li
           key={slot.id}
           className="mx-4 my-2 cursor-pointer rounded bg-blue-100 p-2 text-black hover:bg-blue-300"
-          onClick={() => handleSelectSlot(slot)}
+          onClick={(e) => {
+            e.stopPropagation();
+            handleSelectSlot(slot);
+          }}
         >
           {new Date(slot.start).toLocaleTimeString([], {
             hour: "2-digit",

--- a/src/features/dashboard/components/work-order-list.tsx
+++ b/src/features/dashboard/components/work-order-list.tsx
@@ -10,10 +10,10 @@ export default async function WorkOrderList() {
   const { data: workOrders } = await findAllWorkOrdersHydrated();
   const userRole = await getUserRole();
 
-  const today = DateTime.local().startOf("day");
+  const today = DateTime.local().setZone("America/Denver").startOf("day");
   const endOfDay = today.endOf("day");
   const upcomingStart = today.plus({ days: 1 });
-  const upcomingEnd = DateTime.local().plus({ months: 1 });
+  const upcomingEnd = today.plus({ months: 1 });
 
   const sortByAppointment = (a: HydratedWorkOrder, b: HydratedWorkOrder) => {
     const startA = DateTime.fromISO(a.appointment_start || "");
@@ -28,6 +28,9 @@ export default async function WorkOrderList() {
           if (workOrder.appointment_start) {
             const appointmentStart = DateTime.fromISO(
               workOrder.appointment_start,
+              {
+                zone: "America/Denver",
+              },
             );
             return appointmentStart >= today && appointmentStart <= endOfDay;
           }
@@ -61,6 +64,9 @@ export default async function WorkOrderList() {
           if (workOrder.appointment_start) {
             const appointmentStart = DateTime.fromISO(
               workOrder.appointment_start,
+              {
+                zone: "America/Denver",
+              },
             );
             return appointmentStart < today;
           }
@@ -102,8 +108,12 @@ export default async function WorkOrderList() {
   Object.keys(workOrdersGroupedByTechnician).forEach((technicianId) => {
     const technician = workOrdersGroupedByTechnician[technicianId];
     technician.workOrders.sort((a, b) => {
-      const startA = DateTime.fromISO(a.appointment_start || "");
-      const startB = DateTime.fromISO(b.appointment_start || "");
+      const startA = DateTime.fromISO(a.appointment_start || "").setZone(
+        "America/Denver",
+      );
+      const startB = DateTime.fromISO(b.appointment_start || "").setZone(
+        "America/Denver",
+      );
       return startA < startB ? -1 : startA > startB ? 1 : 0;
     });
   });
@@ -120,7 +130,7 @@ export default async function WorkOrderList() {
       {userRole === "TECHNICIAN" && (
         <>
           <h3 className="text-lg font-bold text-blue-800">
-            Today&apos;s Work Orders - {today.toLocaleString()}:
+            Today&apos;s Work Orders - {today.toFormat("MM/dd/yy")}
           </h3>
           {todayAppointments.length > 0 ? (
             todayAppointments.map((workOrder) => (

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,3 +1,4 @@
+import { DateTime } from "luxon";
 import { clsx, type ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
 
@@ -21,24 +22,25 @@ export function formatTime(time: string) {
   });
 }
 
-export function formatDateTime(dateTime: string) {
-  const date = new Date(dateTime);
+export const formatDateTime = (dateTime: string | null) => {
+  if (!dateTime) return { date: "", startTime: "", endTime: "" };
 
-  return date.toLocaleString("en-US", {
-    month: "2-digit",
-    day: "2-digit",
-    year: "2-digit",
-    hour: "numeric",
-    minute: "2-digit",
-    hour12: true,
-  });
-}
+  const dt = DateTime.fromISO(dateTime, { zone: "utc" }).setZone(
+    "America/Denver",
+  );
+
+  const dateFormat = dt.toLocaleString(DateTime.DATE_MED);
+  const timeFormat = dt.toLocaleString(DateTime.TIME_SIMPLE);
+  const startTime = timeFormat;
+  const endTime = dt.plus({ hours: 1 }).toLocaleString(DateTime.TIME_SIMPLE);
+
+  return {
+    date: dateFormat,
+    startTime,
+    endTime,
+  };
+};
 
 export function formatDateLong(date: Date): string {
-  return date.toLocaleDateString("en-US", {
-    weekday: "long",
-    year: "numeric",
-    month: "long",
-    day: "numeric",
-  });
+  return DateTime.fromJSDate(date).toFormat("MMMM d, yyyy");
 }


### PR DESCRIPTION
# [FE] [DSD-80](https://jarrod-van-doren.atlassian.net/browse/DSD-80?atlOrigin=eyJpIjoiNmRkMTU4OTI1OWFmNGQ4OWI3NmZjMWIzNmU3NWI4YTgiLCJwIjoiaiJ9) - Add timezone library on frontend
# [FE] [DSD-163](https://jarrod-van-doren.atlassian.net/browse/DSD-163?atlOrigin=eyJpIjoiOGYxMjFjYjIyZWU2NGExNzgxYTQxYTdmZmM5NThhZTkiLCJwIjoiaiJ9) - Fix highlighted dates issue
# [FE] [DSD-165](https://jarrod-van-doren.atlassian.net/browse/DSD-165?atlOrigin=eyJpIjoiZjU2MWZlMTA0YmE1NGNmZmJhY2RiMzhkZTYyNmE0MTciLCJwIjoiaiJ9) - Fix step 2 click issue

## Summary
This PR implements three tickets with some inter-related issues. 
The missing timezone library was affecting the highlighted dates. Also while working on highlighted dates in Step 2, the click issue was fixed.

## Changes
The Luxon library was utilized to transform dates to the "America/Denver" timezone. Now all users will see times displayed in Mountain time, but adjusted from their local timezone. 

Changes were made to the calendar in step 2, the timeslot list that displays the timeslot times, step 3 date and time confirmation, the functions fetching dates and timeslots, step 6 displaying the appointment confirmation, and the work order cards displayed on the dashboard.

Now, if a user books an appointment from London (London set in browser location sensor), they will see consistent times alongside what someone would see in Colorado (No override in browser location sensor).

LONDON - entire scheduling process for an appointment on April 2:

Step 2
<img width="889" alt="Screenshot 2025-03-23 at 2 05 50 PM" src="https://github.com/user-attachments/assets/5c69c399-c1bc-4483-b912-e06171400dd1" />
Step 3
<img width="917" alt="Screenshot 2025-03-23 at 2 06 12 PM" src="https://github.com/user-attachments/assets/92bffdc7-2f82-447e-954a-1989e8a3365a" />
Step 6
<img width="835" alt="Screenshot 2025-03-23 at 2 06 22 PM" src="https://github.com/user-attachments/assets/dfb21bd9-da22-4d55-b6f4-9ba2f0a575a5" />
Email confirmation
<img width="636" alt="Screenshot 2025-03-23 at 2 09 33 PM" src="https://github.com/user-attachments/assets/ffff5487-3071-4651-b6fc-a08785713655" />
Database screenshot of times from Work Order
<img width="456" alt="Screenshot 2025-03-23 at 2 09 45 PM" src="https://github.com/user-attachments/assets/3241e165-06e5-42b8-9556-77ab23e2ee09" />
Proof of proper timezone conversion
<img width="1022" alt="Screenshot 2025-03-23 at 2 12 46 PM" src="https://github.com/user-attachments/assets/22fa2515-15c0-435e-8452-04e9a5dd69d6" />
Work Order card on user dashboard
<img width="978" alt="Screenshot 2025-03-23 at 2 19 14 PM" src="https://github.com/user-attachments/assets/57a78b2c-3401-4d0b-b136-2077465f7874" />
The same work order card as above on dashboard but switched location sensor to No override:
<img width="968" alt="Screenshot 2025-03-23 at 2 18 53 PM" src="https://github.com/user-attachments/assets/98eaacae-93d2-491a-9bab-9eee80e19fd4" />


COLORADO - entire scheduling process for an appointment on April 1:
Step 2
<img width="888" alt="Screenshot 2025-03-23 at 2 13 47 PM" src="https://github.com/user-attachments/assets/f97408f1-5053-4cca-b805-0a616f4688d2" />
Step 3
<img width="923" alt="Screenshot 2025-03-23 at 2 13 59 PM" src="https://github.com/user-attachments/assets/6f154a2e-0a86-4df8-93f0-4c8b0ec14943" />
Step 6
<img width="844" alt="Screenshot 2025-03-23 at 2 14 15 PM" src="https://github.com/user-attachments/assets/3586678c-f383-4a9c-8571-d94a914e9123" />
Email confirmation
<img width="639" alt="Screenshot 2025-03-23 at 2 14 37 PM" src="https://github.com/user-attachments/assets/b8c2c245-582e-4c0c-a339-368ecdd02b28" />
Database screenshot of times from Work Order
<img width="453" alt="Screenshot 2025-03-23 at 2 15 10 PM" src="https://github.com/user-attachments/assets/35493fdd-40eb-4285-8221-cad50f55f3ef" />
Proof of proper timezone conversion
<img width="1026" alt="Screenshot 2025-03-23 at 2 15 31 PM" src="https://github.com/user-attachments/assets/cd27f22b-0af8-4faa-89b5-c1b71a47f486" />
Work Order card on user dashboard
<img width="967" alt="Screenshot 2025-03-23 at 2 19 44 PM" src="https://github.com/user-attachments/assets/d0d9b52d-d8b3-4a64-ac21-63b1060fad6f" />
The same work order card as above on dashboard but switched to London location sensor:
<img width="973" alt="Screenshot 2025-03-23 at 2 19 27 PM" src="https://github.com/user-attachments/assets/ee43eeed-eaea-46f4-9bca-c9860de44956" />
