### PR TITLE
bug: Add missing ids to select inputs (DSD-172)

### DIFF
--- a/src/components/schedule/step-1-work-order-form.tsx
+++ b/src/components/schedule/step-1-work-order-form.tsx
@@ -84,6 +84,7 @@ export default function Step1DepartmentService({
           Department
         </label>
         <Select
+          id="department"
           {...register("departmentId", { required: true })}
           onChange={handleDepartmentSelect}
           className="rounded-lg border-r-10 border-transparent bg-blue-100 px-3 py-2 text-sm shadow-lg hover:cursor-pointer md:text-base"
@@ -101,6 +102,7 @@ export default function Step1DepartmentService({
           Service Type
         </label>
         <Select
+          id="serviceType"
           {...register("serviceTypeId", { required: true })}
           className={cn(
             "rounded-lg border-r-10 border-transparent bg-blue-100 px-3 py-2 text-sm shadow-lg hover:cursor-pointer md:text-base",


### PR DESCRIPTION
# [FE] [DSD-172](https://jarrod-van-doren.atlassian.net/browse/DSD-172?atlOrigin=eyJpIjoiNGU5ODcyMzc2YmU4NDNhMmIzNDgyN2I3OTEyMmM2OGMiLCJwIjoiaiJ9) Add missing ids to select inputs

## Summary
There was an error appearing earlier saying:
`label "for" doesn't match any element id`

This PR implements a quick change to solve that error.

## Changes
Add ids to both `Select` inputs in step 1 of the work order form to match the existing `htmlFor` attributes for their corresponding labels.