### PR TITLE
Feat/DSD-177 add job details work order card

### DIFF
--- a/src/features/dashboard/components/work-order-card.tsx
+++ b/src/features/dashboard/components/work-order-card.tsx
@@ -253,28 +253,56 @@ export default function WorkOrderCard({
                 </div>
               </div>
             </div>
-            <div className="mt-2 h-full w-full md:mt-4">
-              <div className="flex justify-center">
-                <div className="flex w-full justify-between rounded-md bg-gray-100 p-2">
-                  <div className="flex flex-col">
-                    <div className="flex">
+            {workOrder.job_details && (
+              <div className="mt-2 h-full w-full md:mt-4">
+                <div className="flex justify-center">
+                  <div className="flex w-full justify-between rounded-md bg-gray-100 p-2">
+                    <div className="flex flex-col">
+                      <div className="flex">
+                        <SmallLabel>Job details:</SmallLabel>
+                      </div>
+                      <p className="pt-1 text-xs md:text-sm">
+                        {workOrder.job_details}
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            )}
+            {userRole === "CLIENT" && workOrder.appointment_notes && (
+              <div className="mt-2 h-full w-full md:mt-4">
+                <div className="flex justify-center">
+                  <div className="flex w-full justify-between rounded-md bg-gray-100 p-2">
+                    <div className="flex flex-col">
                       <SmallLabel>Appointment notes:</SmallLabel>
-                      {(userRole === "TECHNICIAN" || userRole === "ADMIN") && (
+                      <p className="pt-1 text-xs md:text-sm">
+                        {workOrder.appointment_notes}
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            )}
+            {(userRole === "TECHNICIAN" || userRole === "ADMIN") && (
+              <div className="mt-2 h-full w-full md:mt-4">
+                <div className="flex justify-center">
+                  <div className="flex w-full justify-between rounded-md bg-gray-100 p-2">
+                    <div className="flex flex-col">
+                      <div className="flex">
+                        <SmallLabel>Appointment notes:</SmallLabel>
                         <span className="pl-2 text-slate-700 italic">
                           (Appointment notes are visible to the client)
                         </span>
-                      )}
+                      </div>
+                      <p className="pt-1 text-xs md:text-sm">
+                        {workOrder.appointment_notes}
+                      </p>
                     </div>
-                    <p className="pt-1 text-xs md:text-sm">
-                      {workOrder.appointment_notes}
-                    </p>
-                  </div>
-                  {(userRole === "TECHNICIAN" || userRole === "ADMIN") && (
                     <UpdateApptNotesDialog workOrder={workOrder} />
-                  )}
+                  </div>
                 </div>
               </div>
-            </div>
+            )}
             {(userRole === "TECHNICIAN" || userRole === "ADMIN") && (
               <div className="mt-3 w-full md:mt-4">
                 {hasMissingParts && (


### PR DESCRIPTION
# [FE] [DSD-177](https://jarrod-van-doren.atlassian.net/browse/DSD-177?atlOrigin=eyJpIjoiNzQ0MWJkMjU0MTRhNGZhOGE5YmQzOTk1NDFiN2I0MjIiLCJwIjoiaiJ9) Add job details to work order card

## Summary
This PR implements the addition of job details to work order cards and adds conditional rendering for both job details and appointment notes depending on user role.

## Changes
### Clients only see both Job details and appointment notes if there are any. Otherwise, they don't see anything.
Before:
<img width="968" alt="Screenshot 2025-03-24 at 3 20 02 PM" src="https://github.com/user-attachments/assets/5a04fd62-60b2-434a-b16d-3fdcffd3a4c4" />

After:
<img width="998" alt="Screenshot 2025-03-24 at 3 16 19 PM" src="https://github.com/user-attachments/assets/5806f5ae-926c-401c-9322-a5a30d4777f8" />

### Technicians and Admins will only see "Job Details" if the client provided any, but they will always see "Appointment notes" so they can edit/add notes as needed.

Before:
<img width="974" alt="Screenshot 2025-03-24 at 3 20 41 PM" src="https://github.com/user-attachments/assets/51db5ea0-63f5-4a2a-97e2-69d64bd0e1e4" />

After:
<img width="1001" alt="Screenshot 2025-03-24 at 3 15 43 PM" src="https://github.com/user-attachments/assets/853d5acb-90a6-4d20-881a-aa41e9e24a83" />
