### PR TITLE
Feat/DSD-179 add aria step labels

### DIFF
--- a/src/components/schedule/schedule-work-order-form.tsx
+++ b/src/components/schedule/schedule-work-order-form.tsx
@@ -265,6 +265,7 @@ export default function ScheduleWorkOrderForm({
             setIsDisabled={setIsDisabled}
             isDisabled={isDisabled}
             setAllTimeslots={setAllTimeslots}
+            step={step}
             nextStep={nextStep}
             setValue={setValue}
           />
@@ -280,6 +281,7 @@ export default function ScheduleWorkOrderForm({
             allTimeslots={allTimeslots}
             setFilteredSlots={setFilteredSlots}
             filteredSlots={filteredSlots}
+            step={step}
             prevStep={prevStep}
             setStep={setStep}
           />
@@ -287,6 +289,7 @@ export default function ScheduleWorkOrderForm({
         {step === 3 && (
           <Step3ConfirmDateTime
             formValues={getValues()}
+            step={step}
             prevStep={prevStep}
             nextStep={nextStep}
           />
@@ -298,6 +301,7 @@ export default function ScheduleWorkOrderForm({
             userProfile={userProfile}
             setSelectedAddress={setSelectedAddress}
             selectedAddress={selectedAddress}
+            step={step}
             prevStep={prevStep}
             nextStep={nextStep}
           />
@@ -312,6 +316,7 @@ export default function ScheduleWorkOrderForm({
             formValues={getValues()}
             selectedAddress={selectedAddress}
             userProfile={userProfile}
+            step={step}
             prevStep={prevStep}
             nextStep={nextStep}
           />
@@ -323,6 +328,7 @@ export default function ScheduleWorkOrderForm({
             departmentName={departmentName}
             serviceTypeName={serviceTypeName}
             selectedDate={selectedDate}
+            step={step}
             prevStep={prevStep}
             isSubmitting={isSubmitting}
           />

--- a/src/components/schedule/step-1-work-order-form.tsx
+++ b/src/components/schedule/step-1-work-order-form.tsx
@@ -26,6 +26,7 @@ interface Step1DepartmentServiceProps {
   setIsDisabled: React.Dispatch<React.SetStateAction<boolean>>;
   isDisabled: boolean;
   setAllTimeslots: React.Dispatch<React.SetStateAction<Timeslot[]>>;
+  step: number;
   nextStep: () => void;
   setValue: UseFormSetValue<CreateWorkOrderInput>;
 }
@@ -42,6 +43,7 @@ export default function Step1DepartmentService({
   setIsDisabled,
   isDisabled,
   setAllTimeslots,
+  step,
   nextStep,
   setValue,
 }: Step1DepartmentServiceProps) {
@@ -85,7 +87,10 @@ export default function Step1DepartmentService({
   };
 
   return (
-    <div className="-mt-10 w-11/12 max-w-[500px] self-center rounded-lg bg-white p-4 shadow-lg sm:w-3/4 sm:p-6 md:w-3/5 lg:w-1/2">
+    <div
+      aria-current={step === 1 ? "step" : undefined}
+      className="-mt-10 w-11/12 max-w-[500px] self-center rounded-lg bg-white p-4 shadow-lg sm:w-3/4 sm:p-6 md:w-3/5 lg:w-1/2"
+    >
       <h1 className="mb-6 text-center text-2xl font-medium lg:text-3xl">
         Schedule an Appointment
       </h1>

--- a/src/components/schedule/step-2-work-order-form.tsx
+++ b/src/components/schedule/step-2-work-order-form.tsx
@@ -24,6 +24,7 @@ interface Step2SelectDateTimeProps {
   allTimeslots: Timeslot[];
   setFilteredSlots: React.Dispatch<React.SetStateAction<Timeslot[]>>;
   filteredSlots: Timeslot[];
+  step: number;
   prevStep: () => void;
   setStep: React.Dispatch<React.SetStateAction<number>>;
   setValue: UseFormSetValue<CreateWorkOrderInput>;
@@ -38,6 +39,7 @@ export default function Step2SelectDateTime({
   allTimeslots,
   setFilteredSlots,
   filteredSlots,
+  step,
   prevStep,
   setStep,
   setValue,
@@ -148,7 +150,10 @@ export default function Step2SelectDateTime({
 
   return (
     <>
-      <div className="flex flex-col items-center justify-center px-2 pb-2">
+      <div
+        aria-current={step === 2 ? "step" : undefined}
+        className="flex flex-col items-center justify-center px-2 pb-2"
+      >
         <h2 className="pb-1 text-center text-base font-semibold md:text-lg">
           Click on an available date highlighted in green:
         </h2>

--- a/src/components/schedule/step-3-work-order-form.tsx
+++ b/src/components/schedule/step-3-work-order-form.tsx
@@ -4,12 +4,14 @@ import StepButtons from "./step-buttons";
 import { CreateWorkOrderInput } from "@/features/work-orders/schemas";
 
 interface Step3ConfirmDateTimeProps {
+  step: number;
   prevStep: () => void;
   nextStep: () => void;
   formValues: CreateWorkOrderInput;
 }
 
 export default function Step3ConfirmDateTime({
+  step,
   prevStep,
   nextStep,
   formValues,
@@ -25,7 +27,10 @@ export default function Step3ConfirmDateTime({
   };
 
   return (
-    <div className="-mt-10 flex flex-col items-center justify-center px-2">
+    <div
+      aria-current={step === 3 ? "step" : undefined}
+      className="-mt-10 flex flex-col items-center justify-center px-2"
+    >
       <h2 className="flex pb-2 text-center text-base font-semibold md:text-lg">
         Confirm your selected appointment time:
       </h2>

--- a/src/components/schedule/step-4-work-order-form.tsx
+++ b/src/components/schedule/step-4-work-order-form.tsx
@@ -11,6 +11,7 @@ type PartialProfile = Omit<
 interface Step4SelectAddressProps {
   setSelectedAddress: React.Dispatch<React.SetStateAction<"onFile" | "new">>;
   selectedAddress: "onFile" | "new";
+  step: number;
   prevStep: () => void;
   nextStep: () => void;
   userProfile: PartialProfile;
@@ -19,12 +20,16 @@ interface Step4SelectAddressProps {
 export default function Step4SelectAddress({
   setSelectedAddress,
   selectedAddress,
+  step,
   prevStep,
   nextStep,
   userProfile,
 }: Step4SelectAddressProps) {
   return (
-    <div className="flex flex-col items-center">
+    <div
+      aria-current={step === 4 ? "step" : undefined}
+      className="flex flex-col items-center"
+    >
       <h2 className="flex pb-2 text-center text-base font-semibold md:text-lg">
         Select your service address:
       </h2>

--- a/src/components/schedule/step-5-work-order-form.tsx
+++ b/src/components/schedule/step-5-work-order-form.tsx
@@ -21,6 +21,7 @@ interface Step5ContactInformationProps {
   clearErrors: UseFormClearErrors<CreateWorkOrderInput>;
   formValues: CreateWorkOrderInput;
   selectedAddress: "onFile" | "new";
+  step: number;
   prevStep: () => void;
   nextStep: () => void;
   userProfile: PartialProfile;
@@ -33,6 +34,7 @@ export default function Step5ContactInformation({
   clearErrors,
   formValues,
   selectedAddress,
+  step,
   prevStep,
   nextStep,
   userProfile,
@@ -44,7 +46,10 @@ export default function Step5ContactInformation({
   };
 
   return (
-    <div className="m-2 flex flex-col items-center">
+    <div
+      aria-current={step === 5 ? "step" : undefined}
+      className="m-2 flex flex-col items-center"
+    >
       <h2 className="flex pb-2 text-center text-base font-semibold md:text-lg">
         {selectedAddress === "onFile" ? "Confirm" : "Enter"} your contact
         information:

--- a/src/components/schedule/step-6-work-order-form.tsx
+++ b/src/components/schedule/step-6-work-order-form.tsx
@@ -14,6 +14,7 @@ interface Step6ConfirmAppointmentProps {
   departmentName: string;
   serviceTypeName: string;
   selectedDate: Date | null;
+  step: number;
   prevStep: () => void;
   isSubmitting: boolean;
 }
@@ -23,6 +24,7 @@ export default function Step6ConfirmAppointment({
   formValues,
   departmentName,
   serviceTypeName,
+  step,
   prevStep,
   isSubmitting,
 }: Step6ConfirmAppointmentProps) {
@@ -37,7 +39,7 @@ export default function Step6ConfirmAppointment({
   };
 
   return (
-    <div>
+    <div aria-current={step === 6 ? "step" : undefined}>
       <h2 className="pb-2 text-center text-base font-semibold md:text-lg">
         Confirm &amp; submit your
         <span className="block"> appointment information:</span>

--- a/src/features/dashboard/components/work-order-card.tsx
+++ b/src/features/dashboard/components/work-order-card.tsx
@@ -253,28 +253,56 @@ export default function WorkOrderCard({
                 </div>
               </div>
             </div>
-            <div className="mt-2 h-full w-full md:mt-4">
-              <div className="flex justify-center">
-                <div className="flex w-full justify-between rounded-md bg-gray-100 p-2">
-                  <div className="flex flex-col">
-                    <div className="flex">
+            {workOrder.job_details && (
+              <div className="mt-2 h-full w-full md:mt-4">
+                <div className="flex justify-center">
+                  <div className="flex w-full justify-between rounded-md bg-gray-100 p-2">
+                    <div className="flex flex-col">
+                      <div className="flex">
+                        <SmallLabel>Job details:</SmallLabel>
+                      </div>
+                      <p className="pt-1 text-xs md:text-sm">
+                        {workOrder.job_details}
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            )}
+            {userRole === "CLIENT" && workOrder.appointment_notes && (
+              <div className="mt-2 h-full w-full md:mt-4">
+                <div className="flex justify-center">
+                  <div className="flex w-full justify-between rounded-md bg-gray-100 p-2">
+                    <div className="flex flex-col">
                       <SmallLabel>Appointment notes:</SmallLabel>
-                      {(userRole === "TECHNICIAN" || userRole === "ADMIN") && (
+                      <p className="pt-1 text-xs md:text-sm">
+                        {workOrder.appointment_notes}
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            )}
+            {(userRole === "TECHNICIAN" || userRole === "ADMIN") && (
+              <div className="mt-2 h-full w-full md:mt-4">
+                <div className="flex justify-center">
+                  <div className="flex w-full justify-between rounded-md bg-gray-100 p-2">
+                    <div className="flex flex-col">
+                      <div className="flex">
+                        <SmallLabel>Appointment notes:</SmallLabel>
                         <span className="pl-2 text-slate-700 italic">
                           (Appointment notes are visible to the client)
                         </span>
-                      )}
+                      </div>
+                      <p className="pt-1 text-xs md:text-sm">
+                        {workOrder.appointment_notes}
+                      </p>
                     </div>
-                    <p className="pt-1 text-xs md:text-sm">
-                      {workOrder.appointment_notes}
-                    </p>
-                  </div>
-                  {(userRole === "TECHNICIAN" || userRole === "ADMIN") && (
                     <UpdateApptNotesDialog workOrder={workOrder} />
-                  )}
+                  </div>
                 </div>
               </div>
-            </div>
+            )}
             {(userRole === "TECHNICIAN" || userRole === "ADMIN") && (
               <div className="mt-3 w-full md:mt-4">
                 {hasMissingParts && (


### PR DESCRIPTION
# [FE] [DSD-179](https://jarrod-van-doren.atlassian.net/jira/software/projects/DSD/boards/1/backlog?selectedIssue=DSD-179&atlOrigin=eyJpIjoiOTliNTY5M2U3NTBjNDk0OGIyMDc0N2ExYjljNTJiM2QiLCJwIjoiaiJ9) Add aria labels to work order form steps

## Summary
This PR implements the addition of aria labels to indicate each step number of the work order form.

## Changes
Step prop passed to all components and each work order step component has an indicator for screen readers about what step they are on:
<img width="369" alt="Screenshot 2025-03-24 at 4 39 49 PM" src="https://github.com/user-attachments/assets/abc9e015-6da8-42ff-a087-4527c6b5db91" />
