### PR TITLE
Feat/DSD-185 add reserved parts email

### DIFF
--- a/src/utils/email-service.ts
+++ b/src/utils/email-service.ts
@@ -1,10 +1,9 @@
-
-import { 
-  generateClientEmailTemplate, 
+import {
+  generateClientEmailTemplate,
   generateTechnicianEmailTemplate,
   generateAdminMissingPartsTemplate,
-  sendEmail
-} from './email-templates';
+  sendEmail,
+} from "./email-templates";
 
 export type ServiceAddress = {
   addressLine1: string;
@@ -12,6 +11,14 @@ export type ServiceAddress = {
   city: string;
   state: string;
   postalCode: string;
+};
+
+export type ReservedPart = {
+  partId: number;
+  partName?: string;
+  manufacturer?: string | null;
+  quantityReserved: number;
+  quantityNeeded: number;
 };
 
 export type MissingPart = {
@@ -30,6 +37,7 @@ export type WorkOrderEmailContext = {
   appointmentEnd: string;
   serviceAddress: ServiceAddress;
   serviceTypeName?: string;
+  reservedParts?: ReservedPart[];
   missingParts?: MissingPart[];
   clientName?: string;
   clientLastName?: string;
@@ -48,15 +56,16 @@ export type WorkOrderEmailContext = {
  * @returns Results from email sending operations
  */
 export async function sendWorkOrderEmails(context: WorkOrderEmailContext) {
-  const { 
-    workOrderId, 
-    clientEmail, 
-    technicianEmail, 
+  const {
+    workOrderId,
+    clientEmail,
+    technicianEmail,
     adminEmail,
-    appointmentStart, 
-    appointmentEnd, 
+    appointmentStart,
+    appointmentEnd,
     serviceAddress,
     serviceTypeName,
+    reservedParts,
     missingParts,
     clientName,
     clientLastName,
@@ -66,7 +75,7 @@ export async function sendWorkOrderEmails(context: WorkOrderEmailContext) {
     secondaryPhone,
     jobDetails,
     appointmentNotes,
-    estimatedDuration
+    estimatedDuration,
   } = context;
 
   const emailData = {
@@ -75,6 +84,7 @@ export async function sendWorkOrderEmails(context: WorkOrderEmailContext) {
     appointmentEnd,
     serviceAddress,
     serviceTypeName,
+    reservedParts,
     missingParts,
     clientName,
     clientLastName,
@@ -84,7 +94,7 @@ export async function sendWorkOrderEmails(context: WorkOrderEmailContext) {
     secondaryPhone,
     jobDetails,
     appointmentNotes,
-    estimatedDuration
+    estimatedDuration,
   };
 
   // Send email to client
@@ -92,7 +102,7 @@ export async function sendWorkOrderEmails(context: WorkOrderEmailContext) {
   const clientEmailPromise = sendEmail(
     clientEmail,
     clientTemplate.subject,
-    clientTemplate.html
+    clientTemplate.html,
   );
 
   // Send email to technician
@@ -100,7 +110,7 @@ export async function sendWorkOrderEmails(context: WorkOrderEmailContext) {
   const technicianEmailPromise = sendEmail(
     technicianEmail,
     technicianTemplate.subject,
-    technicianTemplate.html
+    technicianTemplate.html,
   );
 
   // Only send admin email if there are missing parts and we have an admin email
@@ -110,9 +120,13 @@ export async function sendWorkOrderEmails(context: WorkOrderEmailContext) {
     adminEmailPromise = sendEmail(
       adminEmail,
       adminTemplate.subject,
-      adminTemplate.html
+      adminTemplate.html,
     );
   }
 
-  return Promise.all([clientEmailPromise, technicianEmailPromise, adminEmailPromise]);
+  return Promise.all([
+    clientEmailPromise,
+    technicianEmailPromise,
+    adminEmailPromise,
+  ]);
 }

--- a/src/utils/email-templates.ts
+++ b/src/utils/email-templates.ts
@@ -322,7 +322,7 @@ function generateMissingPartsSection(
           <thead>
             <tr>
               <th>Part</th>
-              <th>Quantity Needed</th>
+              <th>Quantity Missing</th>
               <th>Manufacturer</th>
             </tr>
           </thead>

--- a/src/utils/email-templates.ts
+++ b/src/utils/email-templates.ts
@@ -280,8 +280,8 @@ function generateReservedPartsSection(data: WorkOrderEmailData): string {
           <thead>
             <tr>
               <th>Part</th>
-              <th>Qty Needed</th>
-              <th>Qty Reserved</th>
+              <th>Quantity Needed</th>
+              <th>Quantity Reserved</th>
               <th>Manufacturer</th>
             </tr>
           </thead>

--- a/src/utils/email-templates.ts
+++ b/src/utils/email-templates.ts
@@ -275,7 +275,7 @@ function generateReservedPartsSection(data: WorkOrderEmailData): string {
 
   return `
       <div class="reserved-parts">
-        <h3>Reserved Parts</h3>
+        <h3>Reserved Parts for ${data.serviceTypeName}</h3>
         <table>
           <thead>
             <tr>


### PR DESCRIPTION
# [BE] [DSD-185](https://jarrod-van-doren.atlassian.net/browse/DSD-185?atlOrigin=eyJpIjoiYzc5ZGJlMWE5YjY5NDgxYmJiMTZkYWU0NTRhZWZhZjIiLCJwIjoiaiJ9) Add Reserved Parts to Technician Email

## Summary
This PR implements the addition of Reserved Parts to the technician work order email. They see a table with the list of parts needed for the specific service and display the quantity needed beside the quantity reserved. 

## Changes
Add `ReservedParts` type, retrieved data from the reserved parts table and match part ids to the service type part ids to check for quantity needed for the service.

Add `generateReservedPartsSection` with table structure, update styles, and add into technician email above the Missing Parts section.

## Testing
Email successfully sent to technician with Reserved parts table:
<img width="656" alt="Screenshot 2025-03-25 at 3 53 46 PM" src="https://github.com/user-attachments/assets/50ebe112-cca8-4ae9-a0e4-3ed1ab2f927f" />

Updated layout to add Service Type name to table heading:
<img width="405" alt="Screenshot 2025-03-25 at 4 12 32 PM" src="https://github.com/user-attachments/assets/94491a4b-a20c-49b0-a4e9-d0ea66cb2090" />
