### PR TITLE
refactor: Fix mobile display issues

### DIFF
--- a/src/components/home/components/home-hero.tsx
+++ b/src/components/home/components/home-hero.tsx
@@ -20,7 +20,7 @@ export default function HomeHero() {
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 1, delay: 0.4, ease: "easeOut" }}
-              className="relative z-10 text-gray-500 italic"
+              className="relative text-gray-500 italic"
             >
               ...all under one roof!
             </motion.span>

--- a/src/features/dashboard/components/update-appt-notes-dialog.tsx
+++ b/src/features/dashboard/components/update-appt-notes-dialog.tsx
@@ -24,7 +24,7 @@ export const UpdateApptNotesDialog = ({
         onClick={openDialog}
       >
         <FontAwesomeIcon icon={faPencil} />
-        Edit
+        <span className="hidden md:block">Edit</span>
       </Button>
 
       <Dialog


### PR DESCRIPTION
This PR implements some minor style changes to ui elements on mobile.

Changes: 
Remove z-index from the "all under one roof" text so everything under the  mobile menu is blurry:
<img width="516" alt="Screenshot 2025-03-26 at 6 06 47 PM" src="https://github.com/user-attachments/assets/19e82bee-b755-44ac-89d2-58f99f8ab089" />

Update "Edit" button on Technician/Admin work order cards to only have the pencil icon on smaller screens and no "Edit" text:
<img width="508" alt="Screenshot 2025-03-26 at 6 09 50 PM" src="https://github.com/user-attachments/assets/02b645ec-8412-4d32-815d-84bfc21ec187" />
