### PR TITLE
refactor: Tech calendar font sizes

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -49,8 +49,20 @@
   margin: 0px 16px 0px 16px;
 
   @media screen and (max-width: 640) {
-    font-size: x-large;
+    font-size: large;
     margin: 0px 12px 0px 12px;
+    text-align: center;
+  }
+}
+
+.fc .fc-col-header-cell-cushion {
+  @media screen and (max-width: 750) {
+    font-size: 14px;
+    text-align: center;
+  }
+  @media screen and (max-width: 400) {
+    font-size: 12px;
+    text-align: center;
   }
 }
 


### PR DESCRIPTION
Decrease font sizes for technician calendar header on smaller screens

Before:
<img width="397" alt="Screenshot_2025-03-26_at_6 57 05_PM" src="https://github.com/user-attachments/assets/bb15785d-f7f8-47a3-8fc1-0c84165f340f" />

After:
<img width="333" alt="Screenshot 2025-03-26 at 7 06 45 PM" src="https://github.com/user-attachments/assets/ffc7ea9f-9ebc-4bdb-9796-db4cd9c99b68" />
